### PR TITLE
Added a serverTimestamp attribute

### DIFF
--- a/sample/Playground.iOS/Playground.iOS.csproj
+++ b/sample/Playground.iOS/Playground.iOS.csproj
@@ -1,164 +1,165 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
-        <ProductVersion>8.0.30703</ProductVersion>
-        <SchemaVersion>2.0</SchemaVersion>
-        <ProjectGuid>{AD3D7027-ADCC-47BE-B1AF-AE43895DC2A5}</ProjectGuid>
-        <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-        <TemplateGuid>{89a4fe7c-635d-49c9-8d8c-5cd363c0d68d}</TemplateGuid>
-        <OutputType>Exe</OutputType>
-        <RootNamespace>Playground.iOS</RootNamespace>
-        <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-        <AssemblyName>Playground.iOS</AssemblyName>
-        <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
-        <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-        <ProvisioningType>automatic</ProvisioningType>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
-        <DefineConstants>__IOS__;__MOBILE__;__UNIFIED__;DEBUG;LOGGING;</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <MtouchArch>x86_64</MtouchArch>
-        <MtouchLink>None</MtouchLink>
-        <MtouchDebug>true</MtouchDebug>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
-        <DebugType>none</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <MtouchLink>None</MtouchLink>
-        <MtouchArch>x86_64</MtouchArch>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\iPhone\Debug</OutputPath>
-        <DefineConstants>__IOS__;__MOBILE__;__UNIFIED__;DEBUG;LOGGING;</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <MtouchArch>ARM64</MtouchArch>
-        <CodesignKey>iPhone Developer</CodesignKey>
-        <MtouchDebug>true</MtouchDebug>
-        <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-        <MtouchLink>None</MtouchLink>
-        <MtouchInterpreter>-all</MtouchInterpreter>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
-        <DebugType>none</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\iPhone\Release</OutputPath>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <MtouchArch>ARM64</MtouchArch>
-        <CodesignKey>iPhone Developer</CodesignKey>
-        <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-        <MtouchLink>Full</MtouchLink>
-        <MtouchExtraArgs>--linkskip=Newtonsoft.Json</MtouchExtraArgs>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="Main.cs"/>
-        <Compile Include="AppDelegate.cs"/>
-        <Compile Include="Services\Composition\CompositionRoot.cs"/>
-        <Compile Include="Services\UserInteraction\UserInteractionService.cs"/>
-        <None Include="Entitlements.plist"/>
-        <None Include="Info.plist"/>
-        <Compile Include="Properties\AssemblyInfo.cs"/>
-    </ItemGroup>
-    <ItemGroup>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon1024.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon180.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon167.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon152.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon120.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon87.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon80.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon76.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon60.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon58.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon40.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon29.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon20.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <BundleResource Include="Resources\icon_about.png"/>
-        <BundleResource Include="Resources\icon_about%402x.png"/>
-        <BundleResource Include="Resources\icon_about%403x.png"/>
-        <BundleResource Include="Resources\icon_feed.png"/>
-        <BundleResource Include="Resources\icon_feed%402x.png"/>
-        <BundleResource Include="Resources\icon_feed%403x.png"/>
-        <BundleResource Include="Resources\xamarin_logo.png"/>
-        <BundleResource Include="Resources\xamarin_logo%402x.png"/>
-        <BundleResource Include="Resources\xamarin_logo%403x.png"/>
-        <InterfaceDefinition Include="Resources\LaunchScreen.storyboard"/>
-        <BundleResource Include="GoogleService-Info.plist"/>
-    </ItemGroup>
-    <ItemGroup>
-        <Reference Include="System"/>
-        <Reference Include="System.Xml"/>
-        <Reference Include="System.Core"/>
-        <Reference Include="Xamarin.iOS"/>
-        <Reference Include="System.Numerics"/>
-        <Reference Include="System.Numerics.Vectors"/>
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="TTGSnackbar" Version="1.3.5"/>
-        <PackageReference Include="Xamarin.Forms" Version="5.0.0.1874"/>
-        <PackageReference Include="Xamarin.Essentials" Version="1.6.0"/>
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\Playground.Utility\Playground.Utility.csproj">
-            <Project>{ee0d5cce-87df-476b-8faa-2784de48774d}</Project>
-            <Name>Playground.Utility</Name>
-        </ProjectReference>
-        <ProjectReference Include="..\Playground\Playground.csproj">
-            <Project>{E744A90D-A8F6-4F33-955B-20B14317C9F1}</Project>
-            <Name>Playground</Name>
-        </ProjectReference>
-        <ProjectReference Include="..\..\src\Plugin.Firebase.csproj">
-            <Project>{05AEE250-D409-414E-90EA-249656AF8492}</Project>
-            <Name>Plugin.Firebase</Name>
-        </ProjectReference>
-        <ProjectReference Include="..\Playground.iOS.NotificationServiceExtension\Playground.iOS.NotificationServiceExtension.csproj">
-            <IsAppExtension>true</IsAppExtension>
-            <Project>{825F3577-F503-4DFC-9912-8C4CCCCCC1F8}</Project>
-            <Name>Playground.iOS.NotificationServiceExtension</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets"/>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{AD3D7027-ADCC-47BE-B1AF-AE43895DC2A5}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TemplateGuid>{89a4fe7c-635d-49c9-8d8c-5cd363c0d68d}</TemplateGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Playground.iOS</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>Playground.iOS</AssemblyName>
+    <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+    <ProvisioningType>automatic</ProvisioningType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>__IOS__;__MOBILE__;__UNIFIED__;DEBUG;LOGGING;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchLink>None</MtouchLink>
+    <MtouchDebug>true</MtouchDebug>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>__IOS__;__MOBILE__;__UNIFIED__;DEBUG;LOGGING;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchArch>ARM64</MtouchArch>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>None</MtouchLink>
+    <MtouchInterpreter>-all</MtouchInterpreter>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchArch>ARM64</MtouchArch>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>Full</MtouchLink>
+    <MtouchExtraArgs>--linkskip=Newtonsoft.Json</MtouchExtraArgs>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="AppDelegate.cs" />
+    <Compile Include="Services\Composition\CompositionRoot.cs" />
+    <Compile Include="Services\UserInteraction\UserInteractionService.cs" />
+    <None Include="Entitlements.plist" />
+    <None Include="Info.plist" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon1024.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon180.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon167.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon152.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon120.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon87.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon80.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon76.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon60.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon58.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon40.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon29.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon20.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <BundleResource Include="Resources\icon_about.png" />
+    <BundleResource Include="Resources\icon_about%402x.png" />
+    <BundleResource Include="Resources\icon_about%403x.png" />
+    <BundleResource Include="Resources\icon_feed.png" />
+    <BundleResource Include="Resources\icon_feed%402x.png" />
+    <BundleResource Include="Resources\icon_feed%403x.png" />
+    <BundleResource Include="Resources\xamarin_logo.png" />
+    <BundleResource Include="Resources\xamarin_logo%402x.png" />
+    <BundleResource Include="Resources\xamarin_logo%403x.png" />
+    <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />
+    <BundleResource Include="GoogleService-Info.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="TTGSnackbar" Version="1.3.5" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1874" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.6.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Playground.Utility\Playground.Utility.csproj">
+      <Project>{ee0d5cce-87df-476b-8faa-2784de48774d}</Project>
+      <Name>Playground.Utility</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Playground\Playground.csproj">
+      <Project>{E744A90D-A8F6-4F33-955B-20B14317C9F1}</Project>
+      <Name>Playground</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Plugin.Firebase.csproj">
+      <Project>{05AEE250-D409-414E-90EA-249656AF8492}</Project>
+      <Name>Plugin.Firebase</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Playground.iOS.NotificationServiceExtension\Playground.iOS.NotificationServiceExtension.csproj">
+      <IsAppExtension>true</IsAppExtension>
+      <Project>{825F3577-F503-4DFC-9912-8C4CCCCCC1F8}</Project>
+      <Name>Playground.iOS.NotificationServiceExtension</Name>
+      <IsWatchApp>false</IsWatchApp>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/sample/Playground/AssemblyInfo.cs
+++ b/sample/Playground/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 using Xamarin.Forms.Xaml;
 
-[assembly: XamlCompilation(XamlCompilationOptions.Compile)] 
+[assembly: XamlCompilation(XamlCompilationOptions.Compile)]

--- a/src/Android/CloudMessaging/FirebaseCloudMessagingImplementation.cs
+++ b/src/Android/CloudMessaging/FirebaseCloudMessagingImplementation.cs
@@ -57,7 +57,7 @@ namespace Plugin.Firebase.CloudMessaging
             NotificationReceived?.Invoke(this, new FCMNotificationReceivedEventArgs(fcmNotification));
             TryHandleShowLocalNotificationIfNeeded(fcmNotification);
         }
-        
+
         private static void TryHandleShowLocalNotificationIfNeeded(FCMNotification fcmNotification)
         {
             try {

--- a/src/Android/Extensions/DictionaryExtension.cs
+++ b/src/Android/Extensions/DictionaryExtension.cs
@@ -430,7 +430,7 @@ namespace System.Collections.Generic
             }
             return dict;
         }
-        
+
         public static IDictionary<string, object> ToDictionary(this IDictionary<string, Java.Lang.Object> @this)
         {
             var dict = new Dictionary<string, object>();

--- a/src/Android/Extensions/DictionaryExtension.cs
+++ b/src/Android/Extensions/DictionaryExtension.cs
@@ -123,6 +123,12 @@ namespace System.Collections.Generic
                     var attribute = (FirestorePropertyAttribute) attributes[0];
                     map.Put(attribute.PropertyName, property.GetValue(@this));
                 }
+
+                var timestampAttributes = property.GetCustomAttributes(typeof(FirestoreServerTimestampAttribute), true);
+                if(timestampAttributes.Any()) {
+                    var attribute = (FirestoreServerTimestampAttribute) timestampAttributes[0];
+                    map.Put(attribute.PropertyName, Firebase.Firestore.FieldValue.ServerTimestamp());
+                }
             }
             return map;
         }

--- a/src/Android/Extensions/JavaObjectExtensions.cs
+++ b/src/Android/Extensions/JavaObjectExtensions.cs
@@ -43,6 +43,20 @@ namespace Plugin.Firebase.Android.Extensions
                         property.SetValue(instance, value);
                     }
                 }
+
+                var timestampAttributes = property.GetCustomAttributes(typeof(FirestoreServerTimestampAttribute), true);
+                if(timestampAttributes.Any()) {
+                    var attribute = (FirestoreServerTimestampAttribute) timestampAttributes[0];
+                    var value = @this[attribute.PropertyName];
+
+                    if(value == null) {
+                        Console.WriteLine($"[Plugin.Firebase] Couldn't cast property '{attribute.PropertyName}' of '{targetType}' because it's not contained in the dictionary.");
+                    } else if(value is Java.Lang.Object javaValue) {
+                        property.SetValue(instance, javaValue.ToObject(property.PropertyType));
+                    } else {
+                        property.SetValue(instance, value);
+                    }
+                }
             }
             return instance;
         }

--- a/src/Android/Firestore/FirestoreExtensions.cs
+++ b/src/Android/Firestore/FirestoreExtensions.cs
@@ -157,7 +157,7 @@ namespace Plugin.Firebase.Android.Firestore
         {
             return @this.IsDocumentId ? NativeFieldPath.DocumentId() : NativeFieldPath.Of(@this.Fields);
         }
-        
+
         public static ICollectionReference ToAbstract(this CollectionReference @this)
         {
             return new CollectionReferenceWrapper(@this);

--- a/src/Plugin.Firebase.csproj
+++ b/src/Plugin.Firebase.csproj
@@ -8,9 +8,9 @@
         <RootNamespace>Plugin.Firebase</RootNamespace>
 
         <Product>$(AssemblyName) ($(TargetFramework))</Product>
-        <AssemblyVersion>1.1.1</AssemblyVersion>
-        <AssemblyFileVersion>1.1.1</AssemblyFileVersion>
-        <Version>1.1.1</Version>
+        <AssemblyVersion>1.1.3</AssemblyVersion>
+        <AssemblyFileVersion>1.1.3</AssemblyFileVersion>
+        <Version>1.1.3</Version>
         <NeutralLanguage>en</NeutralLanguage>
 
         <!--Don't auto add files for me, I will tell you -->
@@ -21,7 +21,7 @@
 
         <!--Assembly and Namespace info -->
         <PackageId>Plugin.Firebase</PackageId>
-        <PackageVersion>1.1.1</PackageVersion>
+        <PackageVersion>1.1.3</PackageVersion>
 
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/TobiasBuchholz/Plugin.Firebase</PackageProjectUrl>

--- a/src/Plugin.Firebase.csproj
+++ b/src/Plugin.Firebase.csproj
@@ -8,9 +8,9 @@
         <RootNamespace>Plugin.Firebase</RootNamespace>
 
         <Product>$(AssemblyName) ($(TargetFramework))</Product>
-        <AssemblyVersion>1.1.0</AssemblyVersion>
-        <AssemblyFileVersion>1.1.0</AssemblyFileVersion>
-        <Version>1.1.0</Version>
+        <AssemblyVersion>1.1.1</AssemblyVersion>
+        <AssemblyFileVersion>1.1.1</AssemblyFileVersion>
+        <Version>1.1.1</Version>
         <NeutralLanguage>en</NeutralLanguage>
 
         <!--Don't auto add files for me, I will tell you -->
@@ -21,7 +21,7 @@
 
         <!--Assembly and Namespace info -->
         <PackageId>Plugin.Firebase</PackageId>
-        <PackageVersion>1.1.0</PackageVersion>
+        <PackageVersion>1.1.1</PackageVersion>
 
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/TobiasBuchholz/Plugin.Firebase</PackageProjectUrl>

--- a/src/Plugin.Firebase.csproj
+++ b/src/Plugin.Firebase.csproj
@@ -8,9 +8,9 @@
         <RootNamespace>Plugin.Firebase</RootNamespace>
 
         <Product>$(AssemblyName) ($(TargetFramework))</Product>
-        <AssemblyVersion>1.1.3</AssemblyVersion>
-        <AssemblyFileVersion>1.1.3</AssemblyFileVersion>
-        <Version>1.1.3</Version>
+        <AssemblyVersion>1.1.2</AssemblyVersion>
+        <AssemblyFileVersion>1.1.2</AssemblyFileVersion>
+        <Version>1.1.2</Version>
         <NeutralLanguage>en</NeutralLanguage>
 
         <!--Don't auto add files for me, I will tell you -->
@@ -21,7 +21,7 @@
 
         <!--Assembly and Namespace info -->
         <PackageId>Plugin.Firebase</PackageId>
-        <PackageVersion>1.1.1</PackageVersion>
+        <PackageVersion>1.1.2</PackageVersion>
 
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/TobiasBuchholz/Plugin.Firebase</PackageProjectUrl>

--- a/src/Shared/Auth/IAuthTokenResult.cs
+++ b/src/Shared/Auth/IAuthTokenResult.cs
@@ -15,39 +15,39 @@ namespace Plugin.Firebase.Auth
         /// <typeparam name="T">Type of the claim</typeparam>
         /// <returns></returns>
         T GetClaim<T>(string key);
-        
+
         /// <summary>
         /// Stores the ID token’s authentication date. This is the date the user was signed in and NOT the date the token was refreshed.
         /// </summary>
         DateTimeOffset AuthDate { get; }
-        
-        
+
+
         /// <summary>
         /// Stores the entire payload of claims found on the ID token. This includes the standard reserved claims as well as custom claims
         /// set by the developer via the Admin SDK.
         /// </summary>
         IDictionary<string, object> Claims { get; }
-        
+
         /// <summary>
         /// Stores the ID token’s expiration date.
         /// </summary>
         DateTimeOffset ExpirationDate { get; }
-        
+
         /// <summary>
         /// Stores the date that the ID token was issued. This is the date last refreshed and NOT the last authentication date.
         /// </summary>
         DateTimeOffset IssuedAtDate { get; }
-        
+
         /// <summary>
         /// Stores sign-in provider through which the token was obtained. This does not necessarily map to provider IDs.
         /// </summary>
         string SignInProvider { get; }
-        
+
         /// <summary>
         /// Stores sign-in second factor through which the token was obtained.
         /// </summary>
         string SignInSecondFactor { get; }
-        
+
         /// <summary>
         /// Stores the JWT string of the ID token.
         /// </summary>

--- a/src/Shared/Firestore/FirestoreAttributes.cs
+++ b/src/Shared/Firestore/FirestoreAttributes.cs
@@ -20,4 +20,15 @@ namespace Plugin.Firebase.Firestore
         {
         }
     }
+
+    [AttributeUsage(AttributeTargets.Property)]
+    public class FirestoreServerTimestampAttribute : Attribute
+    {
+        public FirestoreServerTimestampAttribute(string propertyName)
+        {
+            PropertyName = propertyName;
+        }
+
+        public string PropertyName { get; }
+    }
 }

--- a/src/Shared/Firestore/IDocumentReference.cs
+++ b/src/Shared/Firestore/IDocumentReference.cs
@@ -77,7 +77,7 @@ namespace Plugin.Firebase.Firestore
         /// </param>
         /// <typeparam name="T">The type of the document item.</typeparam>
         IDisposable AddSnapshotListener<T>(Action<IDocumentSnapshot<T>> onChanged, Action<Exception> onError = null, bool includeMetaDataChanges = false);
-        
+
         /// <summary>
         /// Gets a <c>ICollectionReference</c> object referring to the collection at the specified path within this <c>IDocumentReference</c>.
         /// </summary>

--- a/src/Shared/Firestore/SetOptions.cs
+++ b/src/Shared/Firestore/SetOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Plugin.Firebase.Firestore
 {

--- a/src/iOS/Extensions/DictionaryExtension.cs
+++ b/src/iOS/Extensions/DictionaryExtension.cs
@@ -126,7 +126,7 @@ namespace Plugin.Firebase.iOS.Extensions
             }
             return dict;
         }
-        
+
         public static IDictionary<string, object> ToDictionary(this NSDictionary<NSString, NSObject> @this)
         {
             var dict = new Dictionary<string, object>();

--- a/src/iOS/Extensions/DictionaryExtension.cs
+++ b/src/iOS/Extensions/DictionaryExtension.cs
@@ -98,6 +98,12 @@ namespace Plugin.Firebase.iOS.Extensions
                         dict[attribute.PropertyName] = value.ToNSObject();
                     }
                 }
+
+                var timestampAttributes = property.GetCustomAttributes(typeof(FirestoreServerTimestampAttribute), true);
+                if(timestampAttributes.Any()) {
+                    var attribute = (FirestoreServerTimestampAttribute) timestampAttributes[0];
+                    dict[attribute.PropertyName] = FieldValue.ServerTimestamp();
+                }
             }
             return dict;
         }

--- a/src/iOS/Extensions/DictionaryExtension.cs
+++ b/src/iOS/Extensions/DictionaryExtension.cs
@@ -103,7 +103,7 @@ namespace Plugin.Firebase.iOS.Extensions
                 var timestampAttributes = property.GetCustomAttributes(typeof(FirestoreServerTimestampAttribute), true);
                 if(timestampAttributes.Any()) {
                     var attribute = (FirestoreServerTimestampAttribute) timestampAttributes[0];
-                    dict[attribute.PropertyName] = FieldValue.ServerTimestamp().ToNative();
+                    dict[attribute.PropertyName] = FieldValue.ServerTimestamp().ToNSObject();
                 }
             }
             return dict;

--- a/src/iOS/Extensions/DictionaryExtension.cs
+++ b/src/iOS/Extensions/DictionaryExtension.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Foundation;
 using Plugin.Firebase.Firestore;
+using Plugin.Firebase.iOS.Firestore;
 
 namespace Plugin.Firebase.iOS.Extensions
 {
@@ -102,7 +103,7 @@ namespace Plugin.Firebase.iOS.Extensions
                 var timestampAttributes = property.GetCustomAttributes(typeof(FirestoreServerTimestampAttribute), true);
                 if(timestampAttributes.Any()) {
                     var attribute = (FirestoreServerTimestampAttribute) timestampAttributes[0];
-                    dict[attribute.PropertyName] = FieldValue.ServerTimestamp();
+                    dict[attribute.PropertyName] = FieldValue.ServerTimestamp().ToNative();
                 }
             }
             return dict;

--- a/src/iOS/Extensions/NSObjectExtension.cs
+++ b/src/iOS/Extensions/NSObjectExtension.cs
@@ -39,6 +39,18 @@ namespace Plugin.Firebase.iOS.Extensions
                         property.SetValue(instance, value.ToObject(property.PropertyType));
                     }
                 }
+
+                var timestampAttributes = property.GetCustomAttributes(typeof(FirestoreServerTimestampAttribute), true);
+                if(timestampAttributes.Any()) {
+                    var attribute = (FirestoreServerTimestampAttribute) timestampAttributes[0];
+                    var value = @this[attribute.PropertyName];
+
+                    if(value == null) {
+                        Console.WriteLine($"[Plugin.Firebase] Couldn't cast property '{attribute.PropertyName}' of '{targetType}' because it's not contained in the dictionary.");
+                    } else {
+                        property.SetValue(instance, value.ToObject(property.PropertyType));
+                    }
+                }
             }
             return instance;
         }

--- a/src/iOS/Firestore/FirestoreExtensions.cs
+++ b/src/iOS/Firestore/FirestoreExtensions.cs
@@ -144,7 +144,7 @@ namespace Plugin.Firebase.iOS.Firestore
         {
             return @this.IsDocumentId ? NativeFieldPath.GetDocumentId() : new NativeFieldPath(@this.Fields);
         }
-        
+
         public static ICollectionReference ToAbstract(this CollectionReference @this)
         {
             return new CollectionReferenceWrapper(@this);

--- a/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
@@ -138,7 +138,7 @@ namespace Plugin.Firebase.IntegrationTests.Auth
             await user.DeleteAsync();
             Assert.Null(sut.CurrentUser);
         }
-        
+
         [Fact]
         public async Task retrieves_custom_claims()
         {

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -49,7 +49,7 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
             await document.SetDataAsync(pokemon);
 
             var ServerPokemon = (await sut.GetDocument(path).GetDocumentSnapshotAsync<Pokemon>(Source.Server)).Data;
-            Assert.NotEqual(ServerPokemon.UploadDate, sampleDate); 
+            Assert.NotEqual(ServerPokemon.UploadDate, sampleDate);
         }
 
         [Fact]

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -36,6 +36,23 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         }
 
         [Fact]
+        public async Task records_upload_servertime_to_a_property()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var pokemon = PokemonFactory.CreateBulbasur();
+            var path = $"testing/{pokemon.Id}";
+
+            var sampleDate = pokemon.CreationDate.Subtract(new TimeSpan(1, 0, 0, 0));
+            pokemon.UploadDate = sampleDate;
+
+            var document = sut.GetDocument(path);
+            await document.SetDataAsync(pokemon);
+
+            var ServerPokemon = (await sut.GetDocument(path).GetDocumentSnapshotAsync<Pokemon>(Source.Server)).Data;
+            Assert.NotEqual(ServerPokemon.UploadDate, sampleDate); 
+        }
+
+        [Fact]
         public async Task updates_existing_document()
         {
             var sut = CrossFirebaseFirestore.Current;

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -420,7 +420,7 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
             var subDocument = sut.GetDocument($"{subCollectionPath}/123");
 
             await document.SetDataAsync(pokemon);
-            await subDocument.SetDataAsync(new Dictionary<object, object>() {{"foo", "bar"}});
+            await subDocument.SetDataAsync(new Dictionary<object, object>() { { "foo", "bar" } });
 
             var subCollectionRef1 = sut.GetCollection(subCollectionPath);
             var subCollectionRef2 = document.GetCollection(subCollectionName);

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/Pokemon.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/Pokemon.cs
@@ -118,7 +118,7 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         [FirestoreProperty("creation_date")]
         public DateTimeOffset CreationDate { get; private set; }
 
-        [FirestoreServerTimestamp("UploadedDate")]
+        [FirestoreServerTimestamp("uploadDate")]
         public DateTimeOffset UploadDate { get; set; }
 
         [FirestoreProperty("original_reference")]

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/Pokemon.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/Pokemon.cs
@@ -118,6 +118,9 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         [FirestoreProperty("creation_date")]
         public DateTimeOffset CreationDate { get; private set; }
 
+        [FirestoreServerTimestamp("UploadedDate")]
+        public DateTimeOffset UploadDate { get; set; }
+
         [FirestoreProperty("original_reference")]
         public IDocumentReference OriginalReference { get; private set; }
     }


### PR DESCRIPTION
This new servertimestamp attribute auto-uploads the "real-time" servertime when the property value is written to the database and when reading from the database it returns the saved property value as normal. This addresses #12 

example use:

```
        [FirestoreServerTimestamp("LatestTime")]
        public DateTimeOffset LatestTime { get; set; }
```