### PR TITLE
Revert Xamarin.GooglePlayServices.Auth library to 119.0.0

### DIFF
--- a/sample/Playground.Android/Properties/AndroidManifest.xml
+++ b/sample/Playground.Android/Properties/AndroidManifest.xml
@@ -14,7 +14,7 @@
 			</intent-filter>
 		</activity>
 		<!-- firebase cloud message -->
-        <meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable/ic_push_small" />
+		<meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable/ic_push_small" />
 		<receiver android:name="com.google.firebase.iid.FirebaseInstanceIdInternalReceiver" android:exported="false" />
 		<receiver android:name="com.google.firebase.iid.FirebaseInstanceIdReceiver" android:exported="true" android:permission="com.google.android.c2dm.permission.SEND">
 			<intent-filter>

--- a/src/Plugin.Firebase.csproj
+++ b/src/Plugin.Firebase.csproj
@@ -91,7 +91,7 @@
         <PackageReference Include="Xamarin.Firebase.Messaging" Version="121.1.0" />
         <PackageReference Include="Xamarin.Firebase.Storage" Version="119.2.1" />
         <PackageReference Include="Xamarin.Firebase.Storage.Common" Version="117.0.0" />
-        <PackageReference Include="Xamarin.GooglePlayServices.Auth" Version="120.2.0.2" />
+        <PackageReference Include="Xamarin.GooglePlayServices.Auth" Version="119.0.0" />
         <PackageReference Include="Xamarin.Google.Dagger" Version="2.27.0" />
     </ItemGroup>
 

--- a/src/Plugin.Firebase.csproj
+++ b/src/Plugin.Firebase.csproj
@@ -91,7 +91,7 @@
         <PackageReference Include="Xamarin.Firebase.Messaging" Version="121.1.0" />
         <PackageReference Include="Xamarin.Firebase.Storage" Version="119.2.1" />
         <PackageReference Include="Xamarin.Firebase.Storage.Common" Version="117.0.0" />
-        <PackageReference Include="Xamarin.GooglePlayServices.Auth" Version="119.2.0.3" />
+        <PackageReference Include="Xamarin.GooglePlayServices.Auth" Version="120.2.0.2" />
         <PackageReference Include="Xamarin.Google.Dagger" Version="2.27.0" />
     </ItemGroup>
 

--- a/tests/Plugin.Firebase.TestHarness.Android/Plugin.Firebase.TestHarness.Android.csproj
+++ b/tests/Plugin.Firebase.TestHarness.Android/Plugin.Firebase.TestHarness.Android.csproj
@@ -109,7 +109,7 @@
         <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.3.0.4" />
         <PackageReference Include="Xamarin.Essentials" Version="1.6.0" />
         <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.8" />
-        <PackageReference Include="Xamarin.GooglePlayServices.Auth" Version="119.2.0.3" />
+        <PackageReference Include="Xamarin.GooglePlayServices.Auth" Version="119.0.0" />
         <PackageReference Include="Xamarin.Io.OpenCensus.OpenCensusApi" Version="0.21.0" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />
         <PackageReference Include="xunit.assert" Version="2.4.1" />


### PR DESCRIPTION
Fix #34 (backward compatible with Android 9)