### PR TITLE
Handle weak provider authentication

### DIFF
--- a/src/Android/Auth/FirebaseAuthImplementation.cs
+++ b/src/Android/Auth/FirebaseAuthImplementation.cs
@@ -16,6 +16,7 @@ using Plugin.Firebase.Android.Auth.PhoneNumber;
 using Plugin.Firebase.Common;
 using CrossActionCodeSettings = Plugin.Firebase.Auth.ActionCodeSettings;
 using CrossFirebaseAuthException = Plugin.Firebase.Common.FirebaseAuthException;
+using FirebaseAuthException = Firebase.Auth.FirebaseAuthException;
 
 namespace Plugin.Firebase.Auth
 {
@@ -68,7 +69,12 @@ namespace Plugin.Firebase.Auth
                 FirebaseAuthInvalidUserException => new CrossFirebaseAuthException(FIRAuthError.UserNotFound, ex.Message),
                 FirebaseAuthWeakPasswordException => new CrossFirebaseAuthException(FIRAuthError.WeakPassword, ex.Message),
                 FirebaseAuthInvalidCredentialsException => new CrossFirebaseAuthException(FIRAuthError.InvalidCredential, ex.Message),
-                FirebaseAuthUserCollisionException => new CrossFirebaseAuthException(FIRAuthError.EmailAlreadyInUse, ex.Message),
+                FirebaseAuthUserCollisionException
+                    when (ex as FirebaseAuthException).ErrorCode.Equals("ERROR_EMAIL_ALREADY_IN_USE")
+                    => new CrossFirebaseAuthException(FIRAuthError.EmailAlreadyInUse, ex.Message),
+                FirebaseAuthUserCollisionException
+                    when(ex as FirebaseAuthException).ErrorCode.Equals("ERROR_ACCOUNT_EXISTS_WITH_DIFFERENT_CREDENTIAL")
+                    => new CrossFirebaseAuthException(FIRAuthError.AccountExistsWithDifferentCredential, ex.Message),
                 _ => new CrossFirebaseAuthException(FIRAuthError.Undefined, ex.Message)
             };
         }

--- a/src/Shared/Common/Exceptions/FirebaseAuthException.cs
+++ b/src/Shared/Common/Exceptions/FirebaseAuthException.cs
@@ -40,7 +40,12 @@ namespace Plugin.Firebase.Common
         /// <summary>
         /// Indicates the user's account is disabled.
         /// </summary>
-        UserDisabled
+        UserDisabled,
+        /// <summary>
+        /// Indicates the user already signed in once with a trusted provider and hence, cannot sign in with untrusted provider anymore.
+        /// List of trusted and untrusted providers: https://firebase.google.com/docs/auth/users#verified_email_addresses
+        /// </summary>
+        AccountExistsWithDifferentCredential
     }
 
     public class FirebaseAuthException : FirebaseException


### PR DESCRIPTION
Hi @TobiasBuchholz , this is to fix #56 by raising a `CrossFirebaseAuthException` accordingly with the reason `AccountExistsWithDifferentCredential` anytime a user tries to sign in with untrusted provider while he already signed in once with a trusted provider.

I just saw you raised [1.1.3](https://www.nuget.org/packages/Plugin.Firebase/1.1.3), so I wonder if that would be possible for you to release it in the next couple of weeks please ?

This is the last piece before I can release my app update 😊