### PR TITLE
Update readme with MAUI setup details

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ public static class MauiProgram
     }
 }
 ```
+Ensure that the `.csproj` file's bundle identifier matches that of your firebase project (e.g. `com.company.myapp`). You can open the `google-services.json` file to check what yours is.
+```xml
+<!-- App Identifier -->
+<ApplicationId>com.me.myapp</ApplicationId> <!--FIX THIS-->
+<ApplicationIdGuid>LOTS-OF-HEX-NUMBERS-AND-DASHES</ApplicationIdGuid>
+```
+
+
 
 ### Android specifics
 - Add the following `ItemGroup` to your `.csproj file` to prevent build errors:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ Ensure that the `.csproj` file's bundle identifier matches that of your firebase
 <ApplicationIdGuid>LOTS-OF-HEX-NUMBERS-AND-DASHES</ApplicationIdGuid>
 ```
 
+To avoid build errors about target unsupported frameworks including Mac and Windows, remove them from the `.csproj` file, so that only android and ios remain.
+
+```xml
+<TargetFrameworks>net6.0-android;net6.0-ios;</TargetFrameworks>
+
+<!-- And lower down in the file... -->
+
+<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+```
 
 
 ### Android specifics


### PR DESCRIPTION
Added some small details to avoid errors on initial project setup.

- For firebase to initialize properly the .csproj bundle ID needed to match the google-services.json bundle ID. Note: this seemed to only affect Android builds.
- Added info about removing Mac and Windows target frameworks from .csproj file