### PR TITLE
fix pendingIntent Extras not uptodate

### DIFF
--- a/src/Android/CloudMessaging/FirebaseCloudMessagingImplementation.cs
+++ b/src/Android/CloudMessaging/FirebaseCloudMessagingImplementation.cs
@@ -79,7 +79,8 @@ namespace Plugin.Firebase.CloudMessaging
             var intent = _context.PackageManager.GetLaunchIntentForPackage(_context.PackageName);
             intent.PutExtra(IntentKeyFCMNotification, notification.ToBundle());
             intent.SetFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop);
-            var pendingIntent = PendingIntent.GetActivity(_context, 0, intent, PendingIntentFlags.Immutable);
+            var pendingIntent = PendingIntent.GetActivity(_context, 0, intent,
+                PendingIntentFlags.Immutable | PendingIntentFlags.UpdateCurrent);
             var builder = NotificationBuilderProvider?.Invoke(notification) ?? CreateDefaultNotificationBuilder(notification);
             var notificationManager = (NotificationManager) _context.GetSystemService(Context.NotificationService);
             notificationManager.Notify(1337, builder.SetContentIntent(pendingIntent).Build());


### PR DESCRIPTION
Sending a notifiation+data to an Android App in background and clicking on the tray's notification always returns an old notification. To reproduce the case: [Issue 83](https://github.com/TobiasBuchholz/Plugin.Firebase/issues/83)

Details of the fix and references: [Issue 84](https://github.com/TobiasBuchholz/Plugin.Firebase/issues/84)
