### PR TITLE
Proposal : lazy google/facebook auth

### DIFF
--- a/src/Android/Auth/FirebaseAuthImplementation.cs
+++ b/src/Android/Auth/FirebaseAuthImplementation.cs
@@ -28,14 +28,14 @@ namespace Plugin.Firebase.Auth
 
         public static Task HandleActivityResultAsync(int requestCode, Result resultCode, Intent data)
         {
-            _facebookAuth.HandleActivityResult(requestCode, resultCode, data);
-            return _googleAuth.HandleActivityResultAsync(requestCode, resultCode, data);
+            _facebookAuth.Value.HandleActivityResult(requestCode, resultCode, data);
+            return _googleAuth.Value.HandleActivityResultAsync(requestCode, resultCode, data);
         }
 
         private readonly FirebaseAuth _firebaseAuth;
         private readonly EmailAuth _emailAuth;
-        private static GoogleAuth _googleAuth;
-        private static FacebookAuth _facebookAuth;
+        private static Lazy<GoogleAuth> _googleAuth;
+        private static Lazy<FacebookAuth> _facebookAuth;
         private readonly PhoneNumberAuth _phoneNumberAuth;
         private static string _googleRequestIdToken;
 
@@ -43,8 +43,8 @@ namespace Plugin.Firebase.Auth
         {
             _firebaseAuth = FirebaseAuth.Instance;
             _emailAuth = new EmailAuth();
-            _googleAuth = new GoogleAuth(Activity, _googleRequestIdToken);
-            _facebookAuth = new FacebookAuth();
+            _googleAuth = new Lazy<GoogleAuth>(() => new GoogleAuth(Activity, _googleRequestIdToken));
+            _facebookAuth = new Lazy<FacebookAuth>(() => new FacebookAuth());
             _phoneNumberAuth = new PhoneNumberAuth();
 
             // apply the default app language for sending emails 
@@ -136,7 +136,7 @@ namespace Plugin.Firebase.Auth
         public async Task<IFirebaseUser> SignInWithGoogleAsync()
         {
             try {
-                var credential = await _googleAuth.GetCredentialAsync(FragmentActivity);
+                var credential = await _googleAuth.Value.GetCredentialAsync(FragmentActivity);
                 return await SignInWithCredentialAsync(credential);
             } catch(Exception e) {
                 throw GetFirebaseAuthException(e);
@@ -146,7 +146,7 @@ namespace Plugin.Firebase.Auth
         public async Task<IFirebaseUser> SignInWithFacebookAsync()
         {
             try {
-                var credential = await _facebookAuth.GetCredentialAsync(Activity);
+                var credential = await _facebookAuth.Value.GetCredentialAsync(Activity);
                 return await SignInWithCredentialAsync(credential);
             } catch(Exception e) {
                 throw GetFirebaseAuthException(e);
@@ -197,10 +197,10 @@ namespace Plugin.Firebase.Auth
         public async Task<IFirebaseUser> LinkWithGoogleAsync()
         {
             try {
-                var credential = await _googleAuth.GetCredentialAsync(FragmentActivity);
+                var credential = await _googleAuth.Value.GetCredentialAsync(FragmentActivity);
                 return await LinkWithCredentialAsync(credential);
             } catch(Exception e) {
-                await _googleAuth.SignOutAsync();
+                await _googleAuth.Value.SignOutAsync();
                 throw GetFirebaseAuthException(e);
             }
         }
@@ -208,10 +208,10 @@ namespace Plugin.Firebase.Auth
         public async Task<IFirebaseUser> LinkWithFacebookAsync()
         {
             try {
-                var credential = await _facebookAuth.GetCredentialAsync(Activity);
+                var credential = await _facebookAuth.Value.GetCredentialAsync(Activity);
                 return await LinkWithCredentialAsync(credential);
             } catch(Exception e) {
-                _facebookAuth.SignOut();
+                _facebookAuth.Value.SignOut();
                 throw GetFirebaseAuthException(e);
             }
         }
@@ -239,7 +239,7 @@ namespace Plugin.Firebase.Auth
         {
             try {
                 _firebaseAuth.SignOut();
-                await _googleAuth.SignOutAsync();
+                await _googleAuth.Value.SignOutAsync();
             } catch(Exception e) {
                 throw GetFirebaseAuthException(e);
             }
@@ -277,10 +277,10 @@ namespace Plugin.Firebase.Auth
             Activity as FragmentActivity ?? throw new NullReferenceException($"Current Activity is either null or not of type {nameof(FragmentActivity)}, which is mandatory for sign in with Google");
 
         private static Activity Activity =>
-            Platform.CurrentActivity ?? throw new NullReferenceException("Current Activity is null, ensure that the MainApplication.cs file is setting the CurrentActivity in your source code so Firebase Analytics can use it.");
+            Platform.CurrentActivity ?? throw new NullReferenceException("Current Activity is null, ensure that the MainApplication.cs file is setting the CurrentActivity in your source code so Firebase Auth can use it.");
 
         private static Context AppContext =>
-            Platform.AppContext ?? throw new NullReferenceException("AppContext is null, ensure that the MainApplication.cs file is setting the CurrentActivity in your source code so the Firebase Analytics can use it.");
+            Platform.AppContext ?? throw new NullReferenceException("AppContext is null, ensure that the MainApplication.cs file is setting the CurrentActivity in your source code so the Firebase Auth can use it.");
 
         public IFirebaseUser CurrentUser => _firebaseAuth.CurrentUser?.ToAbstract();
     }

--- a/src/iOS/Auth/FirebaseAuthImplementation.cs
+++ b/src/iOS/Auth/FirebaseAuthImplementation.cs
@@ -50,16 +50,16 @@ namespace Plugin.Firebase.Auth
 
         private readonly FirebaseAuth _firebaseAuth;
         private readonly EmailAuth _emailAuth;
-        private static GoogleAuth _googleAuth;
-        private readonly FacebookAuth _facebookAuth;
+        private static Lazy<GoogleAuth> _googleAuth;
+        private readonly Lazy<FacebookAuth> _facebookAuth;
         private readonly PhoneNumberAuth _phoneNumberAuth;
 
         public FirebaseAuthImplementation()
         {
             _firebaseAuth = FirebaseAuth.DefaultInstance;
             _emailAuth = new EmailAuth();
-            _googleAuth = new GoogleAuth();
-            _facebookAuth = new FacebookAuth();
+            _googleAuth = new Lazy<GoogleAuth>(() => new GoogleAuth());
+            _facebookAuth = new Lazy<FacebookAuth>(() => new FacebookAuth());
             _phoneNumberAuth = new PhoneNumberAuth();
 
             // apply the default app language for sending emails
@@ -155,7 +155,7 @@ namespace Plugin.Firebase.Auth
         public async Task<IFirebaseUser> SignInWithGoogleAsync()
         {
             try {
-                var credential = await _googleAuth.GetCredentialAsync(ViewController);
+                var credential = await _googleAuth.Value.GetCredentialAsync(ViewController);
                 return await SignInWithCredentialAsync(credential);
             } catch(NSErrorException e) {
                 throw GetFirebaseAuthException(e);
@@ -165,7 +165,7 @@ namespace Plugin.Firebase.Auth
         public async Task<IFirebaseUser> SignInWithFacebookAsync()
         {
             try {
-                var credential = await _facebookAuth.GetCredentialAsync(ViewController);
+                var credential = await _facebookAuth.Value.GetCredentialAsync(ViewController);
                 return await SignInWithCredentialAsync(credential);
             } catch(NSErrorException e) {
                 throw GetFirebaseAuthException(e);
@@ -236,10 +236,10 @@ namespace Plugin.Firebase.Auth
         public async Task<IFirebaseUser> LinkWithGoogleAsync()
         {
             try {
-                var credential = await _googleAuth.GetCredentialAsync(ViewController);
+                var credential = await _googleAuth.Value.GetCredentialAsync(ViewController);
                 return await LinkWithCredentialAsync(credential);
             } catch(NSErrorException e) {
-                _googleAuth.SignOut();
+                _googleAuth.Value.SignOut();
                 throw GetFirebaseAuthException(e);
             }
         }
@@ -247,10 +247,10 @@ namespace Plugin.Firebase.Auth
         public async Task<IFirebaseUser> LinkWithFacebookAsync()
         {
             try {
-                var credential = await _facebookAuth.GetCredentialAsync(ViewController);
+                var credential = await _facebookAuth.Value.GetCredentialAsync(ViewController);
                 return await LinkWithCredentialAsync(credential);
             } catch(NSErrorException e) {
-                _facebookAuth.SignOut();
+                _facebookAuth.Value.SignOut();
                 throw GetFirebaseAuthException(e);
             }
         }
@@ -275,8 +275,8 @@ namespace Plugin.Firebase.Auth
 
         public Task SignOutAsync()
         {
-            _googleAuth.SignOut();
-            _facebookAuth.SignOut();
+            _googleAuth.Value.SignOut();
+            _facebookAuth.Value.SignOut();
             _firebaseAuth.SignOut(out var e);
             return Task.CompletedTask;
         }


### PR DESCRIPTION
In this PR, Google and Facebook auth providers are now Lazy.
The goal is to avoid initializing Google/Facebook when the app uses only Firebase Auth.

This is only a proposal. 
Another solution could be to add flags to CrossFirebaseSettings (useGoogleAuth, useFacebookAuth).
What do you think?

