### PR TITLE
Update FirebaseCloudMessagingImplementation.cs

### DIFF
--- a/src/CloudMessaging/Platforms/Android/FirebaseCloudMessagingImplementation.cs
+++ b/src/CloudMessaging/Platforms/Android/FirebaseCloudMessagingImplementation.cs
@@ -67,7 +67,10 @@ public sealed class FirebaseCloudMessagingImplementation : DisposableBase, IFire
     private static void HandleShowLocalNotificationIfNeeded(FCMNotification fcmNotification)
     {
         if(!string.IsNullOrEmpty(fcmNotification.Title) || !string.IsNullOrEmpty(fcmNotification.Body)) {
-            HandleShowLocalNotification(fcmNotification);
+            if(!fcmNotification.Data.ContainsKey("silent"))
+            {
+                HandleShowLocalNotification(fcmNotification);
+            }
         }
     }
 


### PR DESCRIPTION
added support for silent notifications to android. OnNotificationRecieved is still called but no notification is shown.
Works if you add a key,value pair in the fcm data with "silent" as key name.
Sorry its done in two pushes. just a quick suggestion