### PR TITLE
Update FirebaseCloudMessagingImplementation.cs

### DIFF
--- a/src/CloudMessaging/Platforms/iOS/FirebaseCloudMessagingImplementation.cs
+++ b/src/CloudMessaging/Platforms/iOS/FirebaseCloudMessagingImplementation.cs
@@ -66,8 +66,15 @@ public sealed class FirebaseCloudMessagingImplementation : NSObject, IFirebaseCl
     [Export("userNotificationCenter:willPresentNotification:withCompletionHandler:")]
     public void WillPresentNotification(UNUserNotificationCenter center, UNNotification notification, Action<UNNotificationPresentationOptions> completionHandler)
     {
-        OnNotificationReceived(notification.ToFCMNotification());
-        completionHandler(UNNotificationPresentationOptions.Alert);
+        var fcmNotification = notification.ToFCMNotification();
+        OnNotificationReceived(fcmNotification);
+       
+       if(!fcmNotification.Data.ContainsKey("silent"))
+        {
+            completionHandler(UNNotificationPresentationOptions.Alert);
+            
+        }
+        
     }
 
     public void OnNotificationReceived(FCMNotification message)


### PR DESCRIPTION
added support for silent notifications to android. OnNotificationRecieved is still called but no notification is shown.
Works if you add a key,value pair in the fcm data with "silent" as key name.
Sorry its done in two pushes. just a quick suggestion.

this is the ios part