### PR TITLE
Adding synchronous versions of WriteBatch.Commit()

### DIFF
--- a/src/Firestore/Platforms/Android/WriteBatchWrapper.cs
+++ b/src/Firestore/Platforms/Android/WriteBatchWrapper.cs
@@ -63,4 +63,9 @@ public sealed class WriteBatchWrapper : IWriteBatch
     {
         return _wrapped.Commit().AsAsync();
     }
+
+    public void CommitLocal()
+    {
+        _wrapped.Commit();
+    }
 }

--- a/src/Firestore/Platforms/iOS/WriteBatchWrapper.cs
+++ b/src/Firestore/Platforms/iOS/WriteBatchWrapper.cs
@@ -70,4 +70,9 @@ public sealed class WriteBatchWrapper : IWriteBatch
     {
         return _wrapped.CommitAsync();
     }
+
+    public void CommitLocal()
+    {
+        _wrapped.Commit();
+    }
 }

--- a/src/Firestore/Shared/IWriteBatch.cs
+++ b/src/Firestore/Shared/IWriteBatch.cs
@@ -74,4 +74,9 @@ public interface IWriteBatch
     /// Commits all of the writes in this write batch as a single atomic unit.
     /// </summary>
     Task CommitAsync();
+
+    /// <summary>
+    /// Commits all of the writes in this write batch as a single atomic unit. Returns immediately, without waiting for the commit to complete.
+    /// </summary>
+    void CommitLocal();
 }


### PR DESCRIPTION
Adding synchronous versions of WriteBatch.Commit()

I specifically avoided using `Commit` as the method name for this synchronous overload to avoid false positives of static code analyzers that would flag it as having an async overload.

IMO, the ideal way to name these two methods would be `CommitWithCompletionAsync` and `Commit`. However, since the current method is named `CommitAsync,` I chose `CommitLocal` to avoid having it confused as a synchronous overload.