### PR TITLE
Adding AddAuthDidStateChangeListener to FirebaseAuth

### DIFF
--- a/src/Shared/Auth/IFirebaseAuth.cs
+++ b/src/Shared/Auth/IFirebaseAuth.cs
@@ -152,5 +152,15 @@ namespace Plugin.Firebase.Auth
         /// The currently signed in <c>IFirebaseUser</c> object or <c>null</c> if the user is signed out.
         /// </summary>
         IFirebaseUser CurrentUser { get; }
+        
+        /// <summary>
+        /// Registers a block as an "auth state did change" listener. To be invoked when the block is registered, a user with a different UID from the current user has signed in, or the current user has signed out.
+        /// </summary>
+        /// <remarks>
+        /// The block is invoked immediately after it according to it's standard invocation semantics, asynchronously on the main thread. Users should pay special attention to making sure the block does not inadvertently retain objects which should not be retained by the long-lived block. The block itself will be retained until it is unregistered or until the Auth instance is otherwise deallocated.
+        /// </remarks>
+        /// <param name="callback">The block of code to run.</param>
+        /// <returns>An <c>IDisposable</c> that unregisters the listener.</returns>
+        IDisposable AddAuthStateDidChangeListener(Action<IFirebaseAuth, IFirebaseUser> callback);
     }
 }

--- a/src/iOS/Auth/FirebaseAuthImplementation.cs
+++ b/src/iOS/Auth/FirebaseAuthImplementation.cs
@@ -307,6 +307,16 @@ namespace Plugin.Firebase.Auth
         {
             _firebaseAuth.UseEmulatorWithHost(host, port);
         }
+        
+        public IDisposable AddAuthStateDidChangeListener(Action<IFirebaseAuth, IFirebaseUser> callback)
+        {
+            try {
+                var listener = _firebaseAuth.AddAuthStateDidChangeListener((_, user) => callback(this, user.ToAbstract()));
+                return new DisposableWithAction(() => _firebaseAuth.RemoveAuthStateDidChangeListener(listener));
+            } catch(NSErrorException e) {
+                throw GetFirebaseAuthException(e);
+            }
+        }
 
         private static UIViewController ViewController {
             get {


### PR DESCRIPTION
@TobiasBuchholz I figure you'd prefer to keep new feature development on the MAUI branch, but I'd like to introduce this feature in legacy first and then port it forward. I'll explain why.

I'm currently in the process of migrating a Xamarin.Forms app built on Firebase to MAUI. I've been using forked versions of [@f-miyu](https://github.com/f-miyu)'s Firebase plugins. I'm working to swap out f-miyu's plugins with 'legacy' Plugin.Firebase in my XF app as part of my migration plan. Given this, it's more natural for me to close the feature gaps between f-miyu's plugins and Plugin.Firebase on the legacy branch. I'll be validating these changes through my own production pipeline, then porting them forward to the development branch.

Some other features I'll be looking to add in this way real soon:

- (Firestore) Support nullable value type properties on models
- (Firestore) Support enum properties on models
- (Auth) Support auth state listeners