### PR TITLE
Support int properties on IFirestoreObjects on Android

### DIFF
--- a/src/Firestore/Platforms/Android/Extensions/JavaObjectExtensions.cs
+++ b/src/Firestore/Platforms/Android/Extensions/JavaObjectExtensions.cs
@@ -155,6 +155,8 @@ public static class JavaObjectExtensions
                     property.SetValue(instance, javaValue.ToObject(property.PropertyType));
                 } else if(property.PropertyType == typeof(float)) {
                     property.SetValue(instance, Convert.ToSingle(value));
+                } else if((Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType) == typeof(int)) {
+                    property.SetValue(instance, Convert.ToInt32(value));
                 } else {
                     property.SetValue(instance, value);
                 }


### PR DESCRIPTION
This PR allows `int` or `int?` property types on `IFirestoreObject` on Android.

Currently, the Firestore plugin has inconsistent behavior between iOS and Android when setting up an `IFirestoreObject` with an `int` FirestoreProperty. The iOS implementation allows this, but the Android implementation will throw an exception.

It should be noted that Firestore itself only supports 64-bit integers, but I think the plugin should still let developers use 32-bit integers on their models if they want and deal with potential overflow exceptions.

At the very least, we should strive to keep the implementations behaving consistently across platforms.