### PR TITLE
Firestore plugin converts NSNumbers to nullable .NET types (e.g. floa…

### DIFF
--- a/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
@@ -85,7 +85,7 @@ public static class NSObjectExtensions
             return @this.Int32Value;
         }
 
-        switch(Type.GetTypeCode(targetType)) {
+        switch(Type.GetTypeCode(Nullable.GetUnderlyingType(targetType) ?? targetType)) {
             case TypeCode.Boolean:
                 return @this.BoolValue;
             case TypeCode.Char:


### PR DESCRIPTION
…t?, int?, long?)

Fixes https://github.com/TobiasBuchholz/Plugin.Firebase/issues/249