### PR TITLE
Fixed missing DateTime conversion in FireStore

### DIFF
--- a/src/Firestore/Platforms/Android/Extensions/JavaObjectExtensions.cs
+++ b/src/Firestore/Platforms/Android/Extensions/JavaObjectExtensions.cs
@@ -31,6 +31,8 @@ public static class JavaObjectExtensions
                 return x;
             case bool x:
                 return x;
+            case DateTime x:
+                return x.ToJavaDate();
             case DateTimeOffset x:
                 return x.ToJavaDate();
             case FieldValue x:


### PR DESCRIPTION
I've been using FireStore for a moment in Android and I could see that the DateTime case was omitted in the conversion to Java objects.

Minor change.
Thanks @TobiasBuchholz for review :)