### PR TITLE
Fix/Ios notifications not playing sound

### DIFF
--- a/src/CloudMessaging/Platforms/iOS/FirebaseCloudMessagingImplementation.cs
+++ b/src/CloudMessaging/Platforms/iOS/FirebaseCloudMessagingImplementation.cs
@@ -68,9 +68,14 @@ public sealed class FirebaseCloudMessagingImplementation : NSObject, IFirebaseCl
     {
         var fcmNotification = notification.ToFCMNotification();
         OnNotificationReceived(fcmNotification);
+        if(OperatingSystem.IsIOSVersionAtLeast(14)) {
+            completionHandler(UNNotificationPresentationOptions.Banner
+                | UNNotificationPresentationOptions.List
+                | UNNotificationPresentationOptions.Sound);
 
-        if(!fcmNotification.IsSilentInForeground) {
-            completionHandler(UNNotificationPresentationOptions.Alert);
+        } else {
+            completionHandler(UNNotificationPresentationOptions.Alert
+                | UNNotificationPresentationOptions.Sound);
         }
     }
 

--- a/src/CloudMessaging/Platforms/iOS/FirebaseCloudMessagingImplementation.cs
+++ b/src/CloudMessaging/Platforms/iOS/FirebaseCloudMessagingImplementation.cs
@@ -68,14 +68,16 @@ public sealed class FirebaseCloudMessagingImplementation : NSObject, IFirebaseCl
     {
         var fcmNotification = notification.ToFCMNotification();
         OnNotificationReceived(fcmNotification);
-        if(OperatingSystem.IsIOSVersionAtLeast(14)) {
-            completionHandler(UNNotificationPresentationOptions.Banner
-                | UNNotificationPresentationOptions.List
-                | UNNotificationPresentationOptions.Sound);
+        if(!fcmNotification.IsSilentInForeground) {
+            if(OperatingSystem.IsIOSVersionAtLeast(14)) {
+                completionHandler(UNNotificationPresentationOptions.Banner
+                    | UNNotificationPresentationOptions.List
+                    | UNNotificationPresentationOptions.Sound);
 
-        } else {
-            completionHandler(UNNotificationPresentationOptions.Alert
-                | UNNotificationPresentationOptions.Sound);
+            } else {
+                completionHandler(UNNotificationPresentationOptions.Alert
+                    | UNNotificationPresentationOptions.Sound);
+            }
         }
     }
 


### PR DESCRIPTION
Notifications sounds are not being played on iOS while the app is in the foreground.

This issue was addressed in #295 , with the solution being a workaround by manually playing a sound.

Upon further investigation, I have determined the issue to be a missing flag on the `WillPresentNotification` completion handler.
This plays the sound defined within the notification payload's ApnsConfig object (see https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#apnsconfig).

For example, setting the following in your notification will play the user-defined default alert sound (iOS 17.2+):
```
"message": {
  ...
  "apns": {
    "payload": {
      "aps": {
        "sound" : "default"
      }
    }
  }
}
```

Additionally, I have included changes to support the `UNNotificationPresentationOptions` of `Banner` and `List`, introduced in iOS 14 (deprecating `UNNotificationPresentationOptions.Alert`).

_Apologies if I did anything incorrect, this is my first public pull request and I was failing to install the legacy net 6.0 workloads to test, however I have custom implemented the `WillPresentNotification` delegate in my personal projects and is working as intended._