### PR TITLE
Updating all libraries and samples to .net8

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ The new plugin version 1.2.0 now supports .NET MAUI applications with .NET 6 ðŸš
 To get started add the `GoogleService-Info.plist` and the `google-services.json` files to the root folder of your project and include them in the .csproj file like this:
 
 ```xml
-<ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
     <GoogleServicesJson Include="google-services.json" />
 </ItemGroup>
 
-<ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
     <BundleResource Include="GoogleService-Info.plist" />
 </ItemGroup>
 ```
@@ -104,7 +104,7 @@ Ensure the `ApplicationId` in your `.csproj` file matches the `bundle_id` and `p
 The plugin doesn't support Windows or Mac catalyst, so either remove their targets from your `.csproj` file or use  [preprocessor directives](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation) and [MSBuild conditions](https://learn.microsoft.com/de-de/visualstudio/msbuild/msbuild-conditions?view=vs-2022), e.g:
 
 ```xml
-<ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios' OR '$(TargetFramework)' == 'net6.0-android'">
+<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios' OR '$(TargetFramework)' == 'net8.0-android'">
     <PackageReference Include="Plugin.Firebase" Version="1.2.0" />
 </ItemGroup>
 ```
@@ -112,14 +112,14 @@ The plugin doesn't support Windows or Mac catalyst, so either remove their targe
 ### Android specifics
 - For package versions prior to `Plugin.Firebase 2.0.7`, `Plugin.Firebase.Auth 2.0.5`, `Plugin.Firebase.Firestore 2.0.5`, `Plugin.Firebase.Functions 2.0.2` or `Plugin.Firebase.Storage 2.0.2` add the following `ItemGroup` to your `.csproj` file to prevent build errors:
 ```xml
-<ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
   <PackageReference Include="Xamarin.Kotlin.StdLib.Jdk7" Version="1.7.10" ExcludeAssets="build;buildTransitive" />
   <PackageReference Include="Xamarin.Kotlin.StdLib.Jdk8" Version="1.7.10" ExcludeAssets="build;buildTransitive" />
 </ItemGroup>
 ```
 - For later versions add the following `ItemGroup` to your `.csproj` file to prevent build errors:
 ```xml
-<ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">
+<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
     <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.2" />
     <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.3.0.1" />
     <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.3.0.1" />

--- a/sample/Playground/Playground.csproj
+++ b/sample/Playground/Playground.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
 		<RootNamespace>Playground</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
+        <OutputType>Exe</OutputType>
 
 		<!-- Display name -->
 		<ApplicationTitle>Playground</ApplicationTitle>
@@ -20,8 +21,6 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
-    <TargetPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">33</TargetPlatformVersion>
-		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -31,6 +30,12 @@
 		<MauiFont Include="Resources\Fonts\*" />
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    </ItemGroup>
 
     <!-- localization -->
     <ItemGroup>
@@ -92,7 +97,7 @@
     </ItemGroup>
 
     <!-- needed for android build to work -->
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0-android|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-android|AnyCPU'">
       <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     </PropertyGroup>
 

--- a/src/Analytics/Analytics.csproj
+++ b/src/Analytics/Analytics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -64,11 +64,11 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
 
@@ -78,11 +78,11 @@
     </ItemGroup>
 
     <!-- nuget packages -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Xamarin.Firebase.Analytics" Version="121.3.0.3" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="10.24.0" />
     </ItemGroup>
     

--- a/src/Auth.Facebook/Auth.Facebook.csproj
+++ b/src/Auth.Facebook/Auth.Facebook.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <UseMauiEssentials>true</UseMauiEssentials>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -65,11 +65,11 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
     
@@ -80,11 +80,11 @@
     </ItemGroup>
 
     <!-- nuget packages -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Xamarin.Facebook.Android" Version="11.2.0.1" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <PackageReference Include="Xamarin.Facebook.iOS" Version="12.2.0.1" />
     </ItemGroup>
 

--- a/src/Auth.Google/Auth.Google.csproj
+++ b/src/Auth.Google/Auth.Google.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <UseMauiEssentials>true</UseMauiEssentials>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -65,11 +65,11 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
     
@@ -80,11 +80,11 @@
     </ItemGroup>
 
     <!-- nuget packages -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Xamarin.GooglePlayServices.Auth" Version="120.2.0.2" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <PackageReference Include="Xamarin.Google.iOS.SignIn" Version="5.0.2.4" />
     </ItemGroup>
 

--- a/src/Auth/Auth.csproj
+++ b/src/Auth/Auth.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <UseMauiEssentials>true</UseMauiEssentials>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -65,11 +65,11 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
     
@@ -79,11 +79,11 @@
     </ItemGroup>
 
     <!-- nuget packages -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Xamarin.Firebase.Auth" Version="122.2.0" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="10.24.0" />
     </ItemGroup>
     

--- a/src/Bundled/Bundled.csproj
+++ b/src/Bundled/Bundled.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -64,11 +64,11 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
 

--- a/src/CloudMessaging/CloudMessaging.csproj
+++ b/src/CloudMessaging/CloudMessaging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
         
@@ -64,11 +64,11 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
 
@@ -78,11 +78,11 @@
     </ItemGroup>
     
     <!-- nuget packages -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Xamarin.Firebase.Messaging" Version="123.0.8" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="10.24.0" />
     </ItemGroup>
     

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -62,20 +62,20 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
 
     <!-- nuget packages -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
       <PackageReference Include="AdamE.Firebase.iOS.Core" Version="10.24.0.1" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
       <PackageReference Include="GoogleGson" Version="2.9.1" />
       <PackageReference Include="Xamarin.Firebase.Common" Version="120.1.2" />
     </ItemGroup>

--- a/src/Crashlytics/Crashlytics.csproj
+++ b/src/Crashlytics/Crashlytics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -64,11 +64,11 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
 
@@ -78,11 +78,11 @@
     </ItemGroup>
 
     <!-- nuget packages -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Xamarin.Firebase.Crashlytics" Version="118.3.2" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <PackageReference Include="AdamE.Firebase.iOS.Crashlytics" Version="10.24.0" />
     </ItemGroup>
 

--- a/src/DynamicLinks/DynamicLinks.csproj
+++ b/src/DynamicLinks/DynamicLinks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -64,20 +64,20 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
 
     <!-- nuget packages -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Xamarin.Firebase.Dynamic.Links" Version="121.0.2" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <PackageReference Include="AdamE.Firebase.iOS.DynamicLinks" Version="10.24.0-alpha1" />
     </ItemGroup>
 

--- a/src/Firestore/Firestore.csproj
+++ b/src/Firestore/Firestore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -64,11 +64,11 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
     
@@ -78,11 +78,11 @@
     </ItemGroup>
 
     <!-- nuget packages -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Xamarin.Firebase.Firestore" Version="124.8.1.1" />
     </ItemGroup>
     
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="10.24.0" />
     </ItemGroup>
     

--- a/src/Functions/Functions.csproj
+++ b/src/Functions/Functions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -64,11 +64,11 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
 
@@ -78,11 +78,11 @@
     </ItemGroup>
 
     <!-- nuget packages -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Xamarin.Firebase.Functions" Version="120.3.1.3" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <PackageReference Include="AdamE.Firebase.iOS.CloudFunctions" Version="10.24.0" />
     </ItemGroup>
     

--- a/src/RemoteConfig/RemoteConfig.csproj
+++ b/src/RemoteConfig/RemoteConfig.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -64,11 +64,11 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
 
@@ -78,11 +78,11 @@
     </ItemGroup>
 
     <!-- nuget packages -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Xamarin.Firebase.Config" Version="121.1.2" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <PackageReference Include="AdamE.Firebase.iOS.RemoteConfig" Version="10.24.0-alpha1" />
     </ItemGroup>
 

--- a/src/Storage/Storage.csproj
+++ b/src/Storage/Storage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -64,11 +64,11 @@
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <Compile Include="Platforms\Android\**\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <Compile Include="Platforms\iOS\**\*.cs" />
     </ItemGroup>
 
@@ -78,12 +78,12 @@
     </ItemGroup>
 
     <!-- nuget packages -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Xamarin.Firebase.Storage" Version="120.2.1.3" />
         <PackageReference Include="Xamarin.Firebase.Storage.Common" Version="117.0.0.12" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
         <PackageReference Include="AdamE.Firebase.iOS.Storage" Version="10.24.0" />
     </ItemGroup>
 

--- a/tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj
+++ b/tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>Plugin.Firebase.IntegrationTests</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -67,7 +67,7 @@
     </ItemGroup>
 
     <!-- needed for android build to work -->
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0-android|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-android|AnyCPU'">
       <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     </PropertyGroup>
 


### PR DESCRIPTION
Time to update to .net8!

- Latest Android binding libraries have dropped support for .net6/7
- Potential contributors are having trouble contributing due to .net6 just not being on their local machines
- .net9 is just around the corner