### PR TITLE
Use JavaObject constructor instead of addding individual items

### DIFF
--- a/src/Firestore/Platforms/Android/Extensions/ListExtensions.cs
+++ b/src/Firestore/Platforms/Android/Extensions/ListExtensions.cs
@@ -35,11 +35,13 @@ public static class ListExtensions
 
     public static JavaList ToJavaList(this IEnumerable @this)
     {
-        var list = new JavaList();
-        foreach(var item in @this) {
+        // Refactored to address https://github.com/TobiasBuchholz/Plugin.Firebase/issues/392
+        var list = new List<object>();
+        foreach (var item in @this)
+        {
             list.Add(item.ToJavaObject());
         }
-        return list;
+        return new JavaList(list);;
     }
 
 }


### PR DESCRIPTION
This is to avoid an issue in dotnet/android that is resulting in incosistent behaviour when a List has duplicate items.

https://github.com/TobiasBuchholz/Plugin.Firebase/issues/392