### PR TITLE
iOS Firebase 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,41 @@ The migration to `AdamE.Firebase.iOS.*` packages additionally bumps underlying n
 4. Set `[GoogleService-Info.plist|google-services.json]` **build action** behaviour to `[Bundle Resource|GoogleServicesJson]` by Right clicking/Build Action.
 5. (iOS only) Check the Readme at [AdamEssenmacher/GoogleApisForiOSComponents](https://github.com/AdamEssenmacher/GoogleApisForiOSComponents) for additional setup steps that may be required.
 
+### Dependency Management
+This plugin is a wrapper around the iOS/Android Firebase platform bindings. As such, it takes dependencies on the *minimum* versions of the Firebase iOS/Android SDKs that are required to support the features of the plugin.
+
+Therefore, it is up to developers to manage the versions of the Firebase iOS/Android SDKs that are included in their projects. This is done by adding the appropriate `AdamE.Firebase.iOS.*` and `Xamarin.Firebase.*` NuGet packages to your project. This is not strictly required for the plugin to work, but it is recommended to ensure that you are using the latest versions of the Firebase SDKs.
+
+When new major versions of the native SDKs are released, Plugin.Firebase may or may not be compatible with them. It depends on whether or not the major version bumb includes breaking API changes. In such cases, report an issue and the plugin will be updated to support the new version.
+
+#### iOS Dependencies
+
+- AdamE.Firebase.iOS.Analytics
+- AdamE.Firebase.iOS.Auth
+- AdamE.Firebase.iOS.CloudMessaging
+- AdamE.Firebase.iOS.Core
+- AdamE.Firebase.iOS.Crashlytics
+- AdamE.Firebase.iOS.DynamicLinks
+- AdamE.Firebase.iOS.Firestore
+- AdamE.Firebase.iOS.Functions
+- AdamE.Firebase.iOS.RemoteConfig
+- AdamE.Firebase.iOS.Storage
+
+Note: It is recommended to use the same version number for all AdamE.Firebase.iOS.* packages (e.g. 11.6.0)
+
+#### Android Dependencies
+
+- Xamarin.Firebase.Analytics
+- Xamarin.Firebase.Auth
+- Xamarin.Firebase.Messaging
+- Xamarin.Firebase.Common
+- Xamarin.Firebase.Crashlytics
+- Xamarin.Firebase.DynamicLinks
+- Xamarin.Firebase.Firestore
+- Xamarin.Firebase.Functions
+- Xamarin.Firebase.Config
+- Xamarin.Firebase.Storage
+
 ### .NET MAUI support
 The new plugin version 1.2.0 now supports .NET MAUI applications with .NET 6 🚀 
 

--- a/src/Analytics/Analytics.csproj
+++ b/src/Analytics/Analytics.csproj
@@ -83,7 +83,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="11.6.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="[11.0.0,)" />
     </ItemGroup>
     
 </Project>

--- a/src/Analytics/Analytics.csproj
+++ b/src/Analytics/Analytics.csproj
@@ -83,7 +83,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="10.24.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="11.6.0" />
     </ItemGroup>
     
 </Project>

--- a/src/Auth/Auth.csproj
+++ b/src/Auth/Auth.csproj
@@ -89,7 +89,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="11.6.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="[11.0.0,)" />
     </ItemGroup>
     
 </Project>

--- a/src/Auth/Auth.csproj
+++ b/src/Auth/Auth.csproj
@@ -89,7 +89,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="10.24.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="11.6.0" />
     </ItemGroup>
     
 </Project>

--- a/src/CloudMessaging/CloudMessaging.csproj
+++ b/src/CloudMessaging/CloudMessaging.csproj
@@ -83,7 +83,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="10.24.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="11.6.0" />
     </ItemGroup>
     
 </Project>

--- a/src/CloudMessaging/CloudMessaging.csproj
+++ b/src/CloudMessaging/CloudMessaging.csproj
@@ -83,7 +83,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="11.6.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="[11.0.0,)" />
     </ItemGroup>
     
 </Project>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -72,7 +72,7 @@
 
     <!-- nuget packages -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-      <PackageReference Include="AdamE.Firebase.iOS.Core" Version="11.6.0" />
+      <PackageReference Include="AdamE.Firebase.iOS.Core" Version="[11.0.0,)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -72,7 +72,7 @@
 
     <!-- nuget packages -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-      <PackageReference Include="AdamE.Firebase.iOS.Core" Version="10.24.0.1" />
+      <PackageReference Include="AdamE.Firebase.iOS.Core" Version="11.6.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">

--- a/src/Crashlytics/Crashlytics.csproj
+++ b/src/Crashlytics/Crashlytics.csproj
@@ -83,7 +83,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.Crashlytics" Version="11.6.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.Crashlytics" Version="[11.0.0,)" />
     </ItemGroup>
 
 </Project>

--- a/src/Crashlytics/Crashlytics.csproj
+++ b/src/Crashlytics/Crashlytics.csproj
@@ -83,7 +83,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.Crashlytics" Version="10.24.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.Crashlytics" Version="11.6.0" />
     </ItemGroup>
 
 </Project>

--- a/src/DynamicLinks/DynamicLinks.csproj
+++ b/src/DynamicLinks/DynamicLinks.csproj
@@ -78,7 +78,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.DynamicLinks" Version="10.24.0-alpha1" />
+        <PackageReference Include="AdamE.Firebase.iOS.DynamicLinks" Version="11.6.0" />
     </ItemGroup>
 
 </Project>

--- a/src/DynamicLinks/DynamicLinks.csproj
+++ b/src/DynamicLinks/DynamicLinks.csproj
@@ -78,7 +78,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.DynamicLinks" Version="11.6.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.DynamicLinks" Version="[11.0.0,)" />
     </ItemGroup>
 
 </Project>

--- a/src/Firestore/Firestore.csproj
+++ b/src/Firestore/Firestore.csproj
@@ -83,7 +83,7 @@
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="11.6.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="[11.0.0,)" />
     </ItemGroup>
     
 </Project>

--- a/src/Firestore/Firestore.csproj
+++ b/src/Firestore/Firestore.csproj
@@ -83,7 +83,7 @@
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="10.24.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="11.6.0" />
     </ItemGroup>
     
 </Project>

--- a/src/Firestore/Platforms/iOS/Extensions/DateExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/DateExtensions.cs
@@ -1,4 +1,4 @@
-using Firebase.CloudFirestore;
+using Firebase.Core;
 
 namespace Plugin.Firebase.Firestore.Platforms.iOS.Extensions;
 

--- a/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Diagnostics;
 using Firebase.CloudFirestore;
+using Firebase.Core;
 using Foundation;
 using Plugin.Firebase.Core.Platforms.iOS.Extensions;
 

--- a/src/Functions/Functions.csproj
+++ b/src/Functions/Functions.csproj
@@ -83,7 +83,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.CloudFunctions" Version="11.6.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.CloudFunctions" Version="[11.0.0,)" />
     </ItemGroup>
     
 </Project>

--- a/src/Functions/Functions.csproj
+++ b/src/Functions/Functions.csproj
@@ -83,7 +83,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.CloudFunctions" Version="10.24.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.CloudFunctions" Version="11.6.0" />
     </ItemGroup>
     
 </Project>

--- a/src/RemoteConfig/RemoteConfig.csproj
+++ b/src/RemoteConfig/RemoteConfig.csproj
@@ -83,7 +83,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.RemoteConfig" Version="11.6.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.RemoteConfig" Version="[11.0.0,)" />
     </ItemGroup>
 
 </Project>

--- a/src/RemoteConfig/RemoteConfig.csproj
+++ b/src/RemoteConfig/RemoteConfig.csproj
@@ -83,7 +83,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.RemoteConfig" Version="10.24.0-alpha1" />
+        <PackageReference Include="AdamE.Firebase.iOS.RemoteConfig" Version="11.6.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Storage/Storage.csproj
+++ b/src/Storage/Storage.csproj
@@ -84,7 +84,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.Storage" Version="10.24.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.Storage" Version="11.6.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Storage/Storage.csproj
+++ b/src/Storage/Storage.csproj
@@ -84,7 +84,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.Storage" Version="11.6.0" />
+        <PackageReference Include="AdamE.Firebase.iOS.Storage" Version="[11.0.0,)" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Version 11 of the Firebase SDK introduced a breaking API change (moving Timestamp from Firestore to Core), so we have to update.

I also added a note about dependency management. I get the sense that a lot of plugin users are expecting us to pin latest/recent native SDK versions.