### PR TITLE
Update Auth.Google to use AdamE.Google.iOS.SignIn

### DIFF
--- a/src/Auth.Google/Auth.Google.csproj
+++ b/src/Auth.Google/Auth.Google.csproj
@@ -90,7 +90,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="Xamarin.Google.iOS.SignIn" Version="5.0.2.4" />
+        <PackageReference Include="AdamE.Google.iOS.SignIn" Version="8.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Auth.Google/Platforms/iOS/FirebaseAuthGoogleImplementation.cs
+++ b/src/Auth.Google/Platforms/iOS/FirebaseAuthGoogleImplementation.cs
@@ -16,12 +16,12 @@ public sealed class FirebaseAuthGoogleImplementation : DisposableBase, IFirebase
         var clientId = googleServiceDictionary["CLIENT_ID"].ToString();
         SignIn.SharedInstance.Configuration = new Configuration(clientId);
     }
-
+    
     public static bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
     {
         return SignIn.SharedInstance.HandleUrl(url);
     }
-
+    
     private readonly FirebaseAuth _firebaseAuth;
     private static Lazy<GoogleAuth> _googleAuth;
 
@@ -30,7 +30,7 @@ public sealed class FirebaseAuthGoogleImplementation : DisposableBase, IFirebase
         _firebaseAuth = FirebaseAuth.DefaultInstance;
         _googleAuth = new Lazy<GoogleAuth>(() => new GoogleAuth());
     }
-
+    
     public async Task<IFirebaseUser> SignInWithGoogleAsync()
     {
         try {
@@ -40,13 +40,13 @@ public sealed class FirebaseAuthGoogleImplementation : DisposableBase, IFirebase
             throw GetFirebaseAuthException(e);
         }
     }
-
+    
     private async Task<IFirebaseUser> SignInWithCredentialAsync(AuthCredential credential)
     {
         var authResult = await _firebaseAuth.SignInWithCredentialAsync(credential);
         return authResult.User.ToAbstract(authResult.AdditionalUserInfo);
     }
-
+    
     private static FirebaseAuthException GetFirebaseAuthException(NSErrorException ex)
     {
         AuthErrorCode errorCode;
@@ -59,7 +59,7 @@ public sealed class FirebaseAuthGoogleImplementation : DisposableBase, IFirebase
         Enum.TryParse(errorCode.ToString(), out FIRAuthError authError);
         return new FirebaseAuthException(authError, ex.Error.LocalizedDescription);
     }
-
+    
     public async Task<IFirebaseUser> LinkWithGoogleAsync()
     {
         try {
@@ -70,19 +70,19 @@ public sealed class FirebaseAuthGoogleImplementation : DisposableBase, IFirebase
             throw GetFirebaseAuthException(e);
         }
     }
-
+    
     private async Task<IFirebaseUser> LinkWithCredentialAsync(AuthCredential credential)
     {
         var authResult = await _firebaseAuth.CurrentUser.LinkAsync(credential);
         return authResult.User.ToAbstract(authResult.AdditionalUserInfo);
     }
-
+    
     public Task SignOutAsync()
     {
         _googleAuth.Value.SignOut();
         return Task.CompletedTask;
     }
-
+    
     private static UIViewController ViewController {
         get {
             var rootViewController = UIApplication.SharedApplication.KeyWindow.RootViewController;

--- a/src/Auth.Google/Platforms/iOS/GoogleAuth.cs
+++ b/src/Auth.Google/Platforms/iOS/GoogleAuth.cs
@@ -3,29 +3,25 @@ using Google.SignIn;
 
 namespace Plugin.Firebase.Auth.Platforms.iOS.Google;
 
-public sealed class GoogleAuth : NSObject, ISignInDelegate
+public sealed class GoogleAuth : NSObject
 {
     private UIViewController _viewController;
     private TaskCompletionSource<AuthCredential> _tcs;
-
-    public GoogleAuth()
-    {
-        SignIn.SharedInstance.Delegate = this;
-    }
 
     public Task<AuthCredential> GetCredentialAsync(UIViewController viewController)
     {
         _viewController = viewController;
         _tcs = new TaskCompletionSource<AuthCredential>();
-        SignIn.SharedInstance.PresentingViewController = viewController;
-        SignIn.SharedInstance.SignInUser();
+        SignIn.SharedInstance.SignInWithPresentingViewController(viewController, DidSignIn);
         return _tcs.Task;
     }
 
-    public void DidSignIn(SignIn signIn, GoogleUser user, NSError error)
+    public void DidSignIn(SignInResult signIn, NSError error)
     {
+        var user = signIn.User;
+
         if(user != null && error == null) {
-            _tcs?.SetResult(GoogleAuthProvider.GetCredential(user.Authentication.IdToken, user.Authentication.AccessToken));
+            _tcs?.SetResult(GoogleAuthProvider.GetCredential(user.IdToken.TokenString, user.AccessToken.TokenString));
         } else {
             _tcs?.SetException(new NSErrorException(error));
         }


### PR DESCRIPTION
My project doesn't even build with `Auth.Google` package for iOS, not to mention that it's not supported by Firebase anymore.

Therefore, I have updated it to use `AdamE.Google.iOS.SignIn` instead of abandonned `Xamarin.Google.iOS.SignIn`.