### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Plugin.Firebase
 
-This is a wrapper library around the native Android and iOS Firebase Xamarin SDKs which includes cross-platform APIs for most of the Firebase features.
+This is a wrapper library around the native Android and iOS Firebase Xamarin SDKs which includes cross-platform APIs for most of the Firebase features. Documentation and the included sample app are MAUI-centric, but the plugin should be usable in any cross-platform .NET6+ project.
 
 ## Supported features
 
@@ -19,31 +19,26 @@ This is a wrapper library around the native Android and iOS Firebase Xamarin SDK
 | [Storage](https://firebase.google.com/docs/storage) | [Plugin.Firebase.Storage](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/docs/storage.md) | [![NuGet](https://img.shields.io/nuget/v/plugin.firebase.storage.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Storage/)
 | All in one | [Plugin.Firebase](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/docs/bundled.md) | [![NuGet](https://img.shields.io/nuget/v/plugin.firebase.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase/)
 
-## Version 3.0.0 Notes
-Version 3.0.0 of this plugin marks a migration from the abandoned Microsoft-published Firebase iOS Nuget packages (prefixed with `Xamarin.Firebase.iOS.*` this plugin previously depended on.
-
-Public discussion of the issue can be found on [MAUI's GH](https://github.com/dotnet/maui/discussions/20359)
-
-There should not be any breaking API changes. However, we felt the major version bump was appropriate to communicate the significant change in the plugin's iOS binding dependencies, which are no longer sourced by Microsoft. Moving forward, this plugin will depend on a [community-maintained fork](https://github.com/AdamEssenmacher/GoogleApisForiOSComponents) of the deprecated packages published under a new package prefix `AdamE.Firebase.iOS.*`
-
-The migration to `AdamE.Firebase.iOS.*` packages additionally bumps underlying native Firebase iOS SDKs to version 10.24.0. This is a significant upgrade from the previous latest-available version supported by Microsoft of 8.10. Check the [Firebase iOS SDK release notes](https://firebase.google.com/support/release-notes/ios) to see what's changed, which includes various bug fixes as well as privacy manifest support.
-
 ## Basic setup
+This plugin is a thin wrapper around the native binding packages, which are, in turn, wrappers around the native platform SDKs. As such, developers should not primarily rely on documentation in this plugin for Firebase project configuration or SDK usage. [The official Firebase docs](https://firebase.google.com/docs) should be your primary Firebase resource.
 
 1. Create a Firebase project in the [Firebase Console](https://console.firebase.google.com/), if you don't already have one. If you already have an existing Google project associated with your mobile app, click **Import Google Project**. Otherwise, click **Create New Project**.
 2. Click **Add Firebase to your *[iOS|Android]* app** and follow the setup steps. If you're importing an existing Google project, this may happen automatically and you can just download the config file.
 3. Add `[GoogleService-Info.plist|google-services.json]` file to your app project.
 4. Set `[GoogleService-Info.plist|google-services.json]` **build action** behaviour to `[Bundle Resource|GoogleServicesJson]` by Right clicking/Build Action.
-5. (iOS only) Check the Readme at [AdamEssenmacher/GoogleApisForiOSComponents](https://github.com/AdamEssenmacher/GoogleApisForiOSComponents) for additional setup steps that may be required.
+5. **IMPORTANT (iOS only)** Check the Readme at [AdamEssenmacher/GoogleApisForiOSComponents](https://github.com/AdamEssenmacher/GoogleApisForiOSComponents) for additional setup steps that are required.
+6. Additional setup instructions for individual components (e.g. Auth, Analytics, Firestore, etc.) are linked in the above table.
 
 ### Dependency Management
-This plugin is a wrapper around the iOS/Android Firebase platform bindings. As such, it takes dependencies on the *minimum* versions of the Firebase iOS/Android SDKs that are required to support the features of the plugin.
+The native Firebase SDKs for both Android and iOS have their own set of dependencies--some of which are shared by other common Google libraries. To maximize compatibility and give developers the flexibility to choose from a range of compatible native SDK versions, this plugin's NuGet configuration specifies [version ranges](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges) for the native SDK binding libraries. When resolving dependencies, NuGet's standard behavior is to resolve _minimum_ compatible versions. This ultimately means that developers are responsible for managing versions of the Firebase iOS/Android SDKs that are included in their projects. This is done by adding the appropriate `AdamE.Firebase.iOS.*` and `Xamarin.Firebase.*` NuGet package references to your project. This is not strictly required for the plugin to work, but it is recommended to ensure that you are using the latest versions of the Firebase SDKs, which may include bug fixes or performance improvements internal to the Firebase SDKs.
 
-Therefore, it is up to developers to manage the versions of the Firebase iOS/Android SDKs that are included in their projects. This is done by adding the appropriate `AdamE.Firebase.iOS.*` and `Xamarin.Firebase.*` NuGet packages to your project. This is not strictly required for the plugin to work, but it is recommended to ensure that you are using the latest versions of the Firebase SDKs.
+When new major versions of native SDKs are released, Plugin.Firebase _may or may not_ be compatible with them. It depends on whether or not breaking API changes have been introduced. In such cases, please open an issue (or PR) and the plugin will be updated to support the new version.
 
-When new major versions of the native SDKs are released, Plugin.Firebase may or may not be compatible with them. It depends on whether or not the major version bumb includes breaking API changes. In such cases, report an issue and the plugin will be updated to support the new version.
+The native binding packages are published using a versioning scheme `[MAJOR].[MINOR].[PATCH].[REVISION]`. The MAJOR, MINOR, and PATCH version numbers mirror the native Firebase SDK versions. The REVISION number is incremented if the bindings themselves are updated. (Note: On Android, a '1' is prefixed to the MAJOR version. For example, native Android SDK 24.1.0 is published as 124.1.0.)
 
 #### iOS Dependencies
+
+When selecting package versions for iOS, best practice is to make sure that the MAJOR and MINOR versions match across all packages (e.g. 11.8.*.*). Then, for each package, select the latest PATCH.REVISION.
 
 - AdamE.Firebase.iOS.Analytics
 - AdamE.Firebase.iOS.Auth
@@ -56,9 +51,9 @@ When new major versions of the native SDKs are released, Plugin.Firebase may or 
 - AdamE.Firebase.iOS.RemoteConfig
 - AdamE.Firebase.iOS.Storage
 
-Note: It is recommended to use the same version number for all AdamE.Firebase.iOS.* packages (e.g. 11.6.0)
-
 #### Android Dependencies
+
+When selecting package versions for Android, best practice is to [choose a Firebase BoM](https://firebase.google.com/support/release-notes/android) and select matching package versions for each dependency. As examples, if you wish to use BoM version 33.8.0, then you would want to select Xamarin.Firebase.Analytics v122.2.0 and Xamarin.Firebase.Auth v123.1.0.
 
 - Xamarin.Firebase.Analytics
 - Xamarin.Firebase.Auth
@@ -71,9 +66,7 @@ Note: It is recommended to use the same version number for all AdamE.Firebase.iO
 - Xamarin.Firebase.Config
 - Xamarin.Firebase.Storage
 
-### .NET MAUI support
-The new plugin version 1.2.0 now supports .NET MAUI applications with .NET 6 🚀 
-
+### MAUI Project Configuration
 To get started add the `GoogleService-Info.plist` and the `google-services.json` files to the root folder of your project and include them in the .csproj file like this:
 
 ```xml
@@ -207,41 +200,8 @@ If you would like to use the [Firebase Local Emulator Suite](https://firebase.go
 For example the [`Plugin.Firebase.IntegrationTests`](https://github.com/TobiasBuchholz/Plugin.Firebase/tree/development/tests/Plugin.Firebase.IntegrationTests) project is configured to be able to use the [Cloud Firestore emulator](https://firebase.google.com/docs/emulator-suite/connect_firestore). You can start the emulator with initial seed data by running `firebase emulators:start --only firestore --import=test-data/`. Uncomment the line `CrossFirebaseFirestore.Current.UseEmulator("localhost", 8080);` in [`IntegrationTestAppDelegate.cs`](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/tests/Plugin.Firebase.TestHarness.iOS/IntegrationTestAppDelegate.cs) or [`MainActivity.cs`](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/tests/Plugin.Firebase.TestHarness.Android/MainActivity.cs) to let the test project know it should use the emulator. Now all firestore related tests should pass.
 
 ## Troubleshooting
-#### Windows 11 long path issue
-Problems with the Xamarin.Firebase.iOS.Core package mean that installation can fail on Windows due to long paths See dotnet/maui#17828. To combat this, you need to enable long paths in the registry and move your local nuget cache. You should also keep the path to your project as short as possible.:
-
-##### Powershell
-
-Run in an elevated prompt
-```
-New-ItemProperty `
-    -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
-    -Name "LongPathsEnabled" `
-    -Value 1 `
-    -PropertyType DWORD `
-    -Force
-```
-
-##### Nuget cache
-
-Create a folder named `C:\n`. Add an environment variable:
-
-`NUGET_PACKAGES = C:\n`
-
-**Install package !!!manually via CLI!!!**
-
-Don't open or build the project in VS until you have done the next part.
-
-Navigate to your project folder and run in a command line:
-
-`dotnet add package AdamE.Firebase.iOS.Core`
-
-##### Additional hints:
-- The long path problem is caused by XCFramework format. These are just naturally going to have long file names.
-- Visual Studio (Windows) is fundamentally not compatible with long file names.
-- There's nothing this plugin can do about it. Issues should be opened with the Visual Studio team and the iOS components team over at https://github.com/xamarin/GoogleApisForiOSComponents (for all the good it'll do you...)
-- This doesn't affect macs, which don't have an issue with the long file names.
-- The plugin is still buildable on VS (Windows) as long as you run dotnet restore outside of the IDE. However, the archiving will probably still need to happen on a mac.
+### Windows + Visual Studio + iOS long path issue
+Visual Studio and Windows both have issues with long paths. The issue is explained (along with best-known workarounds) [here](https://github.com/AdamEssenmacher/GoogleApisForiOSComponents?tab=readme-ov-file#windows--visual-studio-long-path-issue).
 
 ## Contributions
 


### PR DESCRIPTION
Just tweaking the README to:

- Direct devs to https://github.com/AdamEssenmacher/GoogleApisForiOSComponents for latest long-path workarounds. Issues are getting reported due to users not following the instructions there and instead using the halfway-working notes here.
- Clarify setup instructions & documentation expectations
- Offer better guidance around dependency management

Also @TobiasBuchholz, can we get Discussions enabled? A lot of "issues" reported are just general questions about Firebase or questions about usage that aren't really actionable. It might be nice to have a space for that stuff that doesn't clutter the Issues section.