### PR TITLE
Add iOS action identifier to notification body

### DIFF
--- a/src/CloudMessaging/Platforms/iOS/FirebaseCloudMessagingImplementation.cs
+++ b/src/CloudMessaging/Platforms/iOS/FirebaseCloudMessagingImplementation.cs
@@ -92,7 +92,13 @@ public sealed class FirebaseCloudMessagingImplementation : NSObject, IFirebaseCl
         if(_notificationTapped == null) {
             _missedTappedNotification = response.Notification.ToFCMNotification();
         } else {
-            _notificationTapped.Invoke(this, new FCMNotificationTappedEventArgs(response.Notification.ToFCMNotification()));
+            var notification = response.Notification.ToFCMNotification();
+            var actionId = response.ActionIdentifier.ToString();
+            if(!string.IsNullOrEmpty(actionId)) 
+            {
+                notification.Data[nameof(response.ActionIdentifier)] = actionId;
+            }
+            _notificationTapped.Invoke(this, new FCMNotificationTappedEventArgs(notification));
         }
 
         completionHandler();


### PR DESCRIPTION
## What problem are we solving?

Currently, notification actions can be created on Android using Android's notifications sdk. Plugin.Firebase does not get in the way for this, especially because android has special "receivers" that are used to handle notification actions. 

On iOS however, the DidReceiveNotificationResponse callback in the IUNUserNotificationCenterDelegate is used to handle all notification taps. This callback is hidden by Plugin.Firebase in the iOS FirebaseCloundMessagingImplementation. iOS will pass a special value in the UNNotificationResponse object passed to the DidReceiveNotificationResponse callback called ActionIdentifier. The value of this is defined when creating notification categories and passing them to the notification center. This identifier is meant to be used to handle custom actions, but is currently lost when using the Plugin.Firebase package.

## How are we fixing it?

This change is relatively simple. In short, if the ActionIdentifier is present on the UNNotificationResponse object passed to the DidReceiveNotificationResponse callback, we store it in the notification object that is passed to the notification tapped event handler. We store it in the Data dictionary(aka the userInfo dictionary). 

This allows the user to access the action identifier which is used for notification actions on iOS. With this property set in the dictionary, custom actions can be handled in the NotificationTapped event handler on iOS.

## Notes

This issue was examined during the investigation of this problem: https://github.com/TobiasBuchholz/Plugin.Firebase/issues/191 .

This new property in the dictionary is platform specific. Therefore code in the notification tapped event handler should be aware of this. 