### PR TITLE
Make it possible to skip the request for an APNs device token

### DIFF
--- a/src/CloudMessaging/Platforms/iOS/FirebaseCloudMessagingImplementation.cs
+++ b/src/CloudMessaging/Platforms/iOS/FirebaseCloudMessagingImplementation.cs
@@ -11,24 +11,35 @@ public sealed class FirebaseCloudMessagingImplementation : NSObject, IFirebaseCl
 {
     private FCMNotification _missedTappedNotification;
 
-    public static void Initialize()
+    public static void Initialize(bool skipApnsDeviceTokenRequest = false)
     {
         var instance = (FirebaseCloudMessagingImplementation) CrossFirebaseCloudMessaging.Current;
-        instance.RegisterForRemoteNotifications();
-        instance.OnTokenRefreshAsync();
+        instance.RegisterForRemoteNotifications(skipApnsDeviceTokenRequest);
+        if(!skipApnsDeviceTokenRequest) {
+            instance.OnTokenRefreshAsync();
+        }
     }
 
-    private void RegisterForRemoteNotifications()
+    private void RegisterForRemoteNotifications(bool skipApnsDeviceTokenRequest)
     {
         if(UIDevice.CurrentDevice.CheckSystemVersion(10, 0)) {
             UNUserNotificationCenter.Current.Delegate = this;
             Messaging.SharedInstance.Delegate = this;
-            UIApplication.SharedApplication.RegisterForRemoteNotifications();
+            if(!skipApnsDeviceTokenRequest) {
+                UIApplication.SharedApplication.RegisterForRemoteNotifications();
+            }
         } else {
             var allNotificationTypes = UIUserNotificationType.Alert | UIUserNotificationType.Badge | UIUserNotificationType.Sound;
             var settings = UIUserNotificationSettings.GetSettingsForTypes(allNotificationTypes, null);
             UIApplication.SharedApplication.RegisterUserNotificationSettings(settings);
         }
+    }
+
+    public static void RequestApnsDeviceToken()
+    {
+        UIApplication.SharedApplication.RegisterForRemoteNotifications();
+        var instance = (FirebaseCloudMessagingImplementation) CrossFirebaseCloudMessaging.Current;
+        instance.OnTokenRefreshAsync();
     }
 
     public Task OnTokenRefreshAsync()


### PR DESCRIPTION
This PR keeps the existing behaviour but makes it possible to skip the registration for an APNs device token on iOS. The change helps the user to create an app which is GDPR/DSGVO ready. Firebase and APNs device token are personal data.
Issue: https://github.com/TobiasBuchholz/Plugin.Firebase/issues/561