### PR TITLE
Firebase Auth - Add ReloadCurrentUserAsync method

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -71,6 +71,15 @@ Since code should be documenting itself you can also take a look at the followin
 - [sample/.../AuthService.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/sample/Playground/Common/Services/Auth/AuthService.cs)
 
 ## Release notes
+- Version 4.x.x
+  - Add `ReloadCurrentUserAsync()` to refresh the currently signed in user from the backend.
+- Version 4.0.0
+  - Upgrade baseline to **.NET 9+**.
+  - Remove MAUI-specific dependencies (Auth remains usable from non-MAUI mobile .NET projects).
+    - Android initialization now requires an `ActivityLocator` function (e.g. `() => Platform.CurrentActivity`).
+  - Raise minimum platform versions (iOS 15+, Android 23+).
+  - Raise minimum Firebase SDK versions (iOS 12.5+, Android BoM 33.0+).
+  - Remove built-in Auth provider implementations (Facebook/Google/Apple); providers must be implemented directly via native SDKs per platform.
 - Version 3.1.2
   - Fix NRE with Google Auth when cancelling sign in (#500)
 - Version 3.1.1

--- a/src/Auth/Platforms/Android/FirebaseAuthImplementation.cs
+++ b/src/Auth/Platforms/Android/FirebaseAuthImplementation.cs
@@ -205,6 +205,18 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return _firebaseAuth.SendPasswordResetEmailAsync(email);
     }
 
+    public async Task ReloadCurrentUserAsync()
+    {
+        var currentUser = _firebaseAuth.CurrentUser;
+        if(currentUser is null) {
+            throw new FirebaseException(
+                "CurrentUser is null. You need to be logged in to use this feature."
+            );
+        }
+
+        await WrapAsync(currentUser.ReloadAsync());
+    }
+
     public void UseEmulator(string host, int port)
     {
         _firebaseAuth.UseEmulator(host, port);

--- a/src/Auth/Platforms/iOS/FirebaseAuthImplementation.cs
+++ b/src/Auth/Platforms/iOS/FirebaseAuthImplementation.cs
@@ -196,6 +196,17 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return _firebaseAuth.SendPasswordResetAsync(email);
     }
 
+    public async Task ReloadCurrentUserAsync()
+    {
+        var currentUser = _firebaseAuth.CurrentUser;
+        if(currentUser is null) {
+            throw new FirebaseException(
+                "CurrentUser is null. You need to be logged in to use this feature."
+            );
+        }
+
+        await WrapAsync(currentUser.ReloadAsync());
+    }
     public void UseEmulator(string host, int port)
     {
         _firebaseAuth.UseEmulatorWithHost(host, port);

--- a/src/Auth/Shared/IFirebaseAuth.cs
+++ b/src/Auth/Shared/IFirebaseAuth.cs
@@ -102,6 +102,12 @@ public interface IFirebaseAuth : IDisposable
     Task SendPasswordResetEmailAsync(string email);
 
     /// <summary>
+    /// Reloads the currently signed in user from the backend.
+    /// </summary>
+    /// <exception cref="Plugin.Firebase.Core.Exceptions.FirebaseException">Thrown when no user is signed in.</exception>
+    Task ReloadCurrentUserAsync();
+
+    /// <summary>
     /// Modify this FirebaseAuth instance to communicate with the Firebase Authentication emulator.
     /// Note: this must be called before this instance has been used to do any operations.
     /// </summary>

--- a/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
@@ -145,6 +145,20 @@ namespace Plugin.Firebase.IntegrationTests.Auth
         }
 
         [Fact]
+        public async Task reloads_current_user()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            await sut.SignInWithEmailAndPasswordAsync("reload-current-user@test.com", "123456");
+            Assert.NotNull(sut.CurrentUser);
+
+            var uid = sut.CurrentUser.Uid;
+            await sut.ReloadCurrentUserAsync();
+
+            Assert.NotNull(sut.CurrentUser);
+            Assert.Equal(uid, sut.CurrentUser.Uid);
+        }
+
+        [Fact]
         public async Task deletes_user()
         {
             var sut = CrossFirebaseAuth.Current;


### PR DESCRIPTION
Hi @AdamEssenmacher , @TobiasBuchholz ,

This pull request introduces a new method to refresh the currently signed-in user from the backend and updates the documentation and integration tests accordingly. It also documents several breaking changes and upgrades in the 4.x.x release.

**New Feature: User Reloading**

* Added `ReloadCurrentUserAsync()` to the `IFirebaseAuth` interface, along with platform-specific implementations for Android and iOS. This method refreshes the currently signed-in user from the backend and throws an exception if no user is signed in. [[1]](diffhunk://#diff-8d4564641819936118ab947228ac7cdb5c7cda209183df8bbfcbc4128d1f4835R104-R109) [[2]](diffhunk://#diff-59f6f4914f7c543e0825580eea06a6d2def560d8af19e45b2072640a8c6083c6R208-R219) [[3]](diffhunk://#diff-aa06a1f161052e0d2c30b07f01db78e965a63606337883b8afca4023acc135e4R199-R209)

**Testing**

* Added an integration test `reloads_current_user` to verify that the current user can be reloaded and remains consistent.

**Documentation**

* Updated `docs/auth.md` with release notes for version 4.x.x, describing the new `ReloadCurrentUserAsync()` method and several breaking changes, including baseline upgrades, removal of MAUI-specific dependencies, raised platform and SDK minimums, and the removal of built-in Auth provider implementations.