### PR TITLE
Firebase Auth - Add SetLanguageCode method

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -70,7 +70,21 @@ Since code should be documenting itself you can also take a look at the followin
 - [tests/.../AuthFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs)
 - [sample/.../AuthService.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/sample/Playground/Common/Services/Auth/AuthService.cs)
 
+## Language
+
+Use `SetLanguageCode("fr")` (or any BCP-47 code) before invoking an Auth flow that triggers user-facing content such as password-reset emails, email-verification emails, or phone-auth SMS.
+Pass `null` or whitespace to reset to the app language (`UseAppLanguage`).
+
 ## Release notes
+- Version 4.x.x
+  - Add `SetLanguageCode(string?)` to control the language used for Auth-generated user-facing flows (reset/verification emails, SMS).
+- Version 4.0.0
+  - Upgrade baseline to **.NET 9+**.
+  - Remove MAUI-specific dependencies (Auth remains usable from non-MAUI mobile .NET projects).
+    - Android initialization now requires an `ActivityLocator` function (e.g. `() => Platform.CurrentActivity`).
+  - Raise minimum platform versions (iOS 15+, Android 23+).
+  - Raise minimum Firebase SDK versions (iOS 12.5+, Android BoM 33.0+).
+  - Remove built-in Auth provider implementations (Facebook/Google/Apple); providers must be implemented directly via native SDKs per platform.
 - Version 3.1.2
   - Fix NRE with Google Auth when cancelling sign in (#500)
 - Version 3.1.1

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -72,12 +72,12 @@ Since code should be documenting itself you can also take a look at the followin
 
 ## Language
 
-Use `SetLanguageCode("fr")` (or any BCP-47 code) before invoking an Auth flow that triggers user-facing content such as password-reset emails, email-verification emails, or phone-auth SMS.
-Pass `null` or whitespace to reset to the app language (`UseAppLanguage`).
+Set `LanguageCode = "fr"` (or any BCP-47 code) before invoking an Auth flow that triggers user-facing content such as password-reset emails, email-verification emails, or phone-auth SMS.
+Call `UseAppLanguage()` to reset to the app language.
 
 ## Release notes
 - Version 4.x.x
-  - Add `SetLanguageCode(string?)` to control the language used for Auth-generated user-facing flows (reset/verification emails, SMS).
+  - Add `LanguageCode` and `UseAppLanguage()` to control the language used for Auth-generated user-facing flows (reset/verification emails, SMS).
 - Version 4.0.0
   - Upgrade baseline to **.NET 9+**.
   - Remove MAUI-specific dependencies (Auth remains usable from non-MAUI mobile .NET projects).

--- a/src/Auth/Platforms/Android/FirebaseAuthImplementation.cs
+++ b/src/Auth/Platforms/Android/FirebaseAuthImplementation.cs
@@ -205,6 +205,16 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return _firebaseAuth.SendPasswordResetEmailAsync(email);
     }
 
+    public void SetLanguageCode(string? languageCode)
+    {
+        if(string.IsNullOrWhiteSpace(languageCode)) {
+            _firebaseAuth.UseAppLanguage();
+            return;
+        }
+
+        _firebaseAuth.LanguageCode = languageCode;
+    }
+
     public void UseEmulator(string host, int port)
     {
         _firebaseAuth.UseEmulator(host, port);

--- a/src/Auth/Platforms/Android/FirebaseAuthImplementation.cs
+++ b/src/Auth/Platforms/Android/FirebaseAuthImplementation.cs
@@ -205,21 +205,20 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return _firebaseAuth.SendPasswordResetEmailAsync(email);
     }
 
-    public void SetLanguageCode(string? languageCode)
-    {
-        if(string.IsNullOrWhiteSpace(languageCode)) {
-            _firebaseAuth.UseAppLanguage();
-            return;
-        }
+    public string? LanguageCode {
+        set => _firebaseAuth.LanguageCode = value;
+    }
 
-        _firebaseAuth.LanguageCode = languageCode;
+    public void UseAppLanguage()
+    {
+        _firebaseAuth.UseAppLanguage();
     }
 
     public void UseEmulator(string host, int port)
     {
         _firebaseAuth.UseEmulator(host, port);
     }
-    
+
     public IDisposable AddAuthStateListener(Action<IFirebaseAuth> listener)
     {
         var authStateListener = new AuthStateListener(_ => listener.Invoke(this));
@@ -228,7 +227,7 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
     }
 
     public IFirebaseUser CurrentUser => _firebaseAuth.CurrentUser?.ToAbstract();
-    
+
     private class AuthStateListener : Java.Lang.Object, FirebaseAuth.IAuthStateListener
     {
         private readonly Action<FirebaseAuth> _onAuthStateChanged;
@@ -237,7 +236,7 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         {
             _onAuthStateChanged = onAuthStateChanged;
         }
-        
+
         public void OnAuthStateChanged(FirebaseAuth auth)
         {
             _onAuthStateChanged.Invoke(auth);

--- a/src/Auth/Platforms/iOS/FirebaseAuthImplementation.cs
+++ b/src/Auth/Platforms/iOS/FirebaseAuthImplementation.cs
@@ -196,28 +196,28 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return _firebaseAuth.SendPasswordResetAsync(email);
     }
 
-    public void SetLanguageCode(string? languageCode)
-    {
-        if(string.IsNullOrWhiteSpace(languageCode)) {
-            _firebaseAuth.UseAppLanguage();
-            return;
-        }
-
-        _firebaseAuth.LanguageCode = languageCode;
+    public string? LanguageCode {
+        set => _firebaseAuth.LanguageCode = value;
     }
-    
+
+    public void UseAppLanguage()
+    {
+        _firebaseAuth.UseAppLanguage();
+    }
+
     public void UseEmulator(string host, int port)
     {
         _firebaseAuth.UseEmulatorWithHost(host, port);
     }
-    
+
     public IDisposable AddAuthStateListener(Action<IFirebaseAuth> listener)
     {
-        var handle =_firebaseAuth.AddAuthStateDidChangeListener((_, _) => listener.Invoke(this));
+        var handle = _firebaseAuth.AddAuthStateDidChangeListener((_, _) => listener.Invoke(this));
         return new DisposableWithAction(() => _firebaseAuth.RemoveAuthStateDidChangeListener(handle));
     }
 
-    private static UIViewController GetViewController() {
+    private static UIViewController GetViewController()
+    {
         var windowScene = UIApplication.SharedApplication.ConnectedScenes.ToArray()
                 .FirstOrDefault(static x => x.ActivationState == UISceneActivationState.ForegroundActive)
             as UIWindowScene;

--- a/src/Auth/Platforms/iOS/FirebaseAuthImplementation.cs
+++ b/src/Auth/Platforms/iOS/FirebaseAuthImplementation.cs
@@ -196,6 +196,16 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return _firebaseAuth.SendPasswordResetAsync(email);
     }
 
+    public void SetLanguageCode(string? languageCode)
+    {
+        if(string.IsNullOrWhiteSpace(languageCode)) {
+            _firebaseAuth.UseAppLanguage();
+            return;
+        }
+
+        _firebaseAuth.LanguageCode = languageCode;
+    }
+    
     public void UseEmulator(string host, int port)
     {
         _firebaseAuth.UseEmulatorWithHost(host, port);

--- a/src/Auth/Shared/IFirebaseAuth.cs
+++ b/src/Auth/Shared/IFirebaseAuth.cs
@@ -103,10 +103,15 @@ public interface IFirebaseAuth : IDisposable
 
     /// <summary>
     /// Sets the language used by Firebase Auth for user-facing flows such as Auth-generated emails/SMS (password reset, email verification, phone auth).
-    /// Call this before invoking an API that triggers the flow, then reset by passing null/whitespace to use the app language.
+    /// Call this before invoking an API that triggers the flow, then reset by calling <see cref="UseAppLanguage"/>.
     /// </summary>
-    /// <param name="languageCode">A BCP-47 language code (e.g. "fr", "en-GB"), or null to use app language.</param>
-    void SetLanguageCode(string? languageCode);
+    /// <param name="value">A BCP-47 language code (e.g. "fr", "en-GB"), or null to clear.</param>
+    string? LanguageCode { set; }
+
+    /// <summary>
+    /// Uses the app language for Firebase Auth user-facing flows.
+    /// </summary>
+    void UseAppLanguage();
 
     /// <summary>
     /// Modify this FirebaseAuth instance to communicate with the Firebase Authentication emulator.
@@ -115,7 +120,7 @@ public interface IFirebaseAuth : IDisposable
     /// <param name="host">The emulator host (for example, 10.0.2.2 on android and localhost on iOS)</param>
     /// <param name="port">The emulator port (for example, 9099)</param>
     void UseEmulator(string host, int port);
-    
+
     /// <summary>
     /// Registers a listener for authentication state changes.
     /// </summary>

--- a/src/Auth/Shared/IFirebaseAuth.cs
+++ b/src/Auth/Shared/IFirebaseAuth.cs
@@ -102,6 +102,13 @@ public interface IFirebaseAuth : IDisposable
     Task SendPasswordResetEmailAsync(string email);
 
     /// <summary>
+    /// Sets the language used by Firebase Auth for user-facing flows such as Auth-generated emails/SMS (password reset, email verification, phone auth).
+    /// Call this before invoking an API that triggers the flow, then reset by passing null/whitespace to use the app language.
+    /// </summary>
+    /// <param name="languageCode">A BCP-47 language code (e.g. "fr", "en-GB"), or null to use app language.</param>
+    void SetLanguageCode(string? languageCode);
+
+    /// <summary>
     /// Modify this FirebaseAuth instance to communicate with the Firebase Authentication emulator.
     /// Note: this must be called before this instance has been used to do any operations.
     /// </summary>

--- a/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
@@ -145,6 +145,20 @@ namespace Plugin.Firebase.IntegrationTests.Auth
         }
 
         [Fact]
+        public async Task sets_language_code()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            await sut.SignInWithEmailAndPasswordAsync("set-language-code@test.com", "123456");
+
+            var ex = Record.Exception(() => {
+                sut.SetLanguageCode("fr");
+                sut.SetLanguageCode(null);
+                sut.SetLanguageCode("   ");
+            });
+            Assert.Null(ex);
+        }
+
+        [Fact]
         public async Task deletes_user()
         {
             var sut = CrossFirebaseAuth.Current;

--- a/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
@@ -151,9 +151,9 @@ namespace Plugin.Firebase.IntegrationTests.Auth
             await sut.SignInWithEmailAndPasswordAsync("set-language-code@test.com", "123456");
 
             var ex = Record.Exception(() => {
-                sut.SetLanguageCode("fr");
-                sut.SetLanguageCode(null);
-                sut.SetLanguageCode("   ");
+                sut.LanguageCode = "fr";
+                sut.UseAppLanguage();
+                sut.LanguageCode = null;
             });
             Assert.Null(ex);
         }


### PR DESCRIPTION
Hi @AdamEssenmacher , @TobiasBuchholz ,

This pull request introduces support for setting the language used in Firebase Auth user-facing flows (such as password reset and verification emails or SMS) via a new `SetLanguageCode` method. The feature is implemented across shared interfaces and both Android and iOS platform implementations, and is documented in the public API and release notes. Additionally, a new integration test ensures the method behaves correctly.

**New Language Control Feature:**

* Added `SetLanguageCode(string? languageCode)` method to the `IFirebaseAuth` interface to allow setting a BCP-47 language code for Auth-generated emails and SMS, or resetting to the app language by passing `null` or whitespace.
* Implemented `SetLanguageCode` in both Android (`FirebaseAuthImplementation.cs`) and iOS (`FirebaseAuthImplementation.cs`) platform classes, using the appropriate Firebase Auth API calls to set or reset the language. [[1]](diffhunk://#diff-59f6f4914f7c543e0825580eea06a6d2def560d8af19e45b2072640a8c6083c6R208-R217) [[2]](diffhunk://#diff-aa06a1f161052e0d2c30b07f01db78e965a63606337883b8afca4023acc135e4R199-R208)

**Documentation and Release Notes:**

* Updated `docs/auth.md` to document the new language control feature and added release notes for version 4.x.x, highlighting the addition of `SetLanguageCode`, baseline upgrades, and breaking changes.

**Testing:**

* Added an integration test (`sets_language_code`) in `AuthFixture.cs` to verify that calling `SetLanguageCode` with valid, null, and whitespace arguments does not throw exceptions.