### PR TITLE
Expand native integration test coverage

### DIFF
--- a/src/Auth/Platforms/Android/Extensions/JavaObjectExtensions.cs
+++ b/src/Auth/Platforms/Android/Extensions/JavaObjectExtensions.cs
@@ -1,4 +1,5 @@
 using Android.Runtime;
+using AndroidX.Collection;
 using Java.Util;
 using IList = System.Collections.IList;
 
@@ -23,6 +24,8 @@ public static class JavaObjectExtensions
                 return x.LongValue();
             case Date x:
                 return x.ToDateTimeOffset();
+            case ArrayMap x:
+                return x.ToDictionary();
             case JavaList x:
                 return x.ToList(targetType?.GenericTypeArguments[0]);
             default:
@@ -80,5 +83,25 @@ public static class JavaObjectExtensions
                     $"Could not convert object of type {@this.GetType()} to Java.Lang.Object"
                 );
         }
+    }
+
+    public static IDictionary<string, object> ToDictionary(this ArrayMap @this)
+    {
+        var dict = new Dictionary<string, object>();
+        var keys = @this.KeySet()!;
+        foreach(var key in keys) {
+            var keyString = key.ToString();
+            if(keyString is null) {
+                throw new ArgumentException("Dictionary contains a null key.");
+            }
+
+            var value = @this.Get(keyString);
+            if(value is null) {
+                throw new ArgumentException("Dictionary contains a null value.");
+            }
+
+            dict[keyString] = value.ToObject();
+        }
+        return dict;
     }
 }

--- a/src/Auth/Platforms/iOS/Extensions/DictionaryExtensions.cs
+++ b/src/Auth/Platforms/iOS/Extensions/DictionaryExtensions.cs
@@ -39,4 +39,19 @@ public static class DictionaryExtensions
         }
         return dict;
     }
+
+    /// <summary>
+    /// Converts an untyped NSDictionary to a .NET dictionary with string keys and object values.
+    /// </summary>
+    /// <param name="this">The NSDictionary to convert.</param>
+    /// <returns>A .NET dictionary containing the converted key-value pairs.</returns>
+    public static IDictionary<string, object> ToDictionary(this NSDictionary @this)
+    {
+        var dict = new Dictionary<string, object>();
+        foreach(NSString key in @this.Keys) {
+            var value = @this.ObjectForKey(key);
+            dict[key.ToString()] = value?.ToObject()!;
+        }
+        return dict;
+    }
 }

--- a/src/Auth/Platforms/iOS/Extensions/NSObjectExtensions.cs
+++ b/src/Auth/Platforms/iOS/Extensions/NSObjectExtensions.cs
@@ -23,6 +23,13 @@ public static class NSObjectExtensions
                 return x.ToString();
             case NSDate x:
                 return x.ToDateTimeOffset();
+            case NSDictionary x when targetType?.GenericTypeArguments?.Length == 2:
+                return x.ToDictionary(
+                    targetType.GenericTypeArguments[0],
+                    targetType.GenericTypeArguments[1]
+                );
+            case NSDictionary x:
+                return x.ToDictionary();
             case NSArray x:
                 return x.ToList(GetGenericListType(targetType)!);
             case NSNull:
@@ -78,12 +85,6 @@ public static class NSObjectExtensions
 
     private static Type? GetGenericListType(Type? targetType)
     {
-        var genericType = targetType?.GenericTypeArguments?.FirstOrDefault();
-        if(genericType == null) {
-            throw new ArgumentException(
-                $"Couldn't get generic list type of targetType {targetType}. Make sure to use a list IList<T> instead of an array T[] as type in your FirestoreObject."
-            );
-        }
-        return genericType;
+        return targetType?.GenericTypeArguments?.FirstOrDefault() ?? typeof(object);
     }
 }

--- a/src/Firestore/Platforms/Android/DocumentReferenceWrapper.cs
+++ b/src/Firestore/Platforms/Android/DocumentReferenceWrapper.cs
@@ -38,16 +38,12 @@ public sealed class DocumentReferenceWrapper : IDocumentReference
 
     public async Task SetDataAsync(params (object, object?)[] data)
     {
-        await Wrapped.Set(data.ToHashMap());
+        await SetDataAsync(data.ToDictionary(x => x.Item1, x => x.Item2));
     }
 
     public async Task SetDataAsync(SetOptions options, params (object, object?)[] data)
     {
-        if(options == null) {
-            await Wrapped.Set(data.ToHashMap());
-        } else {
-            await Wrapped.Set(data.ToHashMap(), options.ToNative());
-        }
+        await SetDataAsync(data.ToDictionary(x => x.Item1, x => x.Item2), options);
     }
 
     public async Task UpdateDataAsync(Dictionary<object, object?> data)

--- a/src/Firestore/Platforms/Android/TransactionWrapper.cs
+++ b/src/Firestore/Platforms/Android/TransactionWrapper.cs
@@ -38,14 +38,12 @@ public sealed class TransactionWrapper : ITransaction
 
     public ITransaction SetData(IDocumentReference document, params (object, object?)[] data)
     {
-        return _wrapped.Set(document.ToNative(), data.ToHashMap()).ToAbstract();
+        return SetData(document, data.ToDictionary(x => x.Item1, x => x.Item2));
     }
 
     public ITransaction SetData(IDocumentReference document, SetOptions options, params (object, object?)[] data)
     {
-        return options == null
-            ? _wrapped.Set(document.ToNative(), data.ToHashMap()).ToAbstract()
-            : _wrapped.Set(document.ToNative(), data.ToHashMap(), options.ToNative()).ToAbstract();
+        return SetData(document, data.ToDictionary(x => x.Item1, x => x.Item2), options);
     }
 
     public ITransaction UpdateData(IDocumentReference document, Dictionary<object, object?> data)

--- a/src/Firestore/Platforms/Android/WriteBatchWrapper.cs
+++ b/src/Firestore/Platforms/Android/WriteBatchWrapper.cs
@@ -34,14 +34,12 @@ public sealed class WriteBatchWrapper : IWriteBatch
 
     public IWriteBatch SetData(IDocumentReference document, params (object, object?)[] data)
     {
-        return _wrapped.Set(document.ToNative(), data.ToHashMap()).ToAbstract();
+        return SetData(document, data.ToDictionary(x => x.Item1, x => x.Item2));
     }
 
     public IWriteBatch SetData(IDocumentReference document, SetOptions options, params (object, object?)[] data)
     {
-        return options == null
-            ? _wrapped.Set(document.ToNative(), data.ToHashMap()).ToAbstract()
-            : _wrapped.Set(document.ToNative(), data.ToHashMap(), options.ToNative()).ToAbstract();
+        return SetData(document, data.ToDictionary(x => x.Item1, x => x.Item2), options);
     }
 
     public IWriteBatch UpdateData(IDocumentReference document, Dictionary<object, object?> data)

--- a/src/Firestore/Platforms/iOS/DocumentReferenceWrapper.cs
+++ b/src/Firestore/Platforms/iOS/DocumentReferenceWrapper.cs
@@ -51,13 +51,13 @@ public sealed class DocumentReferenceWrapper : IDocumentReference
     /// <inheritdoc/>
     public Task SetDataAsync(params (object, object?)[] data)
     {
-        return SetDataAsync(data.ToDictionary());
+        return SetDataAsync(data.ToDictionary(x => x.Item1, x => x.Item2), null);
     }
 
     /// <inheritdoc/>
     public Task SetDataAsync(SetOptions options, params (object, object?)[] data)
     {
-        return SetDataAsync(data.ToDictionary(), options);
+        return SetDataAsync(data.ToDictionary(x => x.Item1, x => x.Item2), options);
     }
 
     /// <inheritdoc/>

--- a/src/Firestore/Platforms/iOS/TransactionWrapper.cs
+++ b/src/Firestore/Platforms/iOS/TransactionWrapper.cs
@@ -79,7 +79,7 @@ public sealed class TransactionWrapper : ITransaction
     /// <inheritdoc/>
     public ITransaction SetData(IDocumentReference document, params (object, object?)[] data)
     {
-        return SetData(document, data.ToDictionary());
+        return SetData(document, data.ToDictionary(x => x.Item1, x => x.Item2));
     }
 
     /// <inheritdoc/>
@@ -89,7 +89,7 @@ public sealed class TransactionWrapper : ITransaction
         params (object, object?)[] data
     )
     {
-        return SetData(document, data.ToDictionary(), options);
+        return SetData(document, data.ToDictionary(x => x.Item1, x => x.Item2), options);
     }
 
     /// <inheritdoc/>

--- a/src/Firestore/Platforms/iOS/WriteBatchWrapper.cs
+++ b/src/Firestore/Platforms/iOS/WriteBatchWrapper.cs
@@ -67,7 +67,7 @@ public sealed class WriteBatchWrapper : IWriteBatch
     /// <inheritdoc/>
     public IWriteBatch SetData(IDocumentReference document, params (object, object?)[] data)
     {
-        return SetData(document, data.ToDictionary());
+        return SetData(document, data.ToDictionary(x => x.Item1, x => x.Item2));
     }
 
     /// <inheritdoc/>
@@ -77,7 +77,7 @@ public sealed class WriteBatchWrapper : IWriteBatch
         params (object, object?)[] data
     )
     {
-        return SetData(document, data.ToDictionary(), options);
+        return SetData(document, data.ToDictionary(x => x.Item1, x => x.Item2), options);
     }
 
     /// <inheritdoc/>

--- a/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
@@ -35,6 +35,20 @@ namespace Plugin.Firebase.IntegrationTests.Auth
         }
 
         [Fact]
+        public async Task sign_in_with_email_and_password_creates_user_automatically()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var email = CreateUniqueEmail("auto-create-sign-in");
+
+            var user = await sut.SignInWithEmailAndPasswordAsync(email, "123456");
+
+            Assert.NotNull(sut.CurrentUser);
+            Assert.Equal(email, user.Email);
+            Assert.Equal(email, sut.CurrentUser.Email);
+            Assert.Equal(user.Uid, sut.CurrentUser.Uid);
+        }
+
+        [Fact]
         public async Task throws_error_if_credentials_are_invalid_when_signing_in_user_via_email_and_password()
         {
             var sut = CrossFirebaseAuth.Current;
@@ -66,6 +80,23 @@ namespace Plugin.Firebase.IntegrationTests.Auth
             Assert.NotNull(user);
             Assert.NotNull(sut.CurrentUser);
             Assert.True(user.IsAnonymous);
+        }
+
+        [Fact]
+        public async Task links_anonymous_user_with_email_and_password()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var anonymousUser = await sut.SignInAnonymouslyAsync();
+            var email = CreateUniqueEmail("link-anonymous");
+
+            var linkedUser = await sut.LinkWithEmailAndPasswordAsync(email, "123456");
+
+            Assert.Equal(anonymousUser.Uid, linkedUser.Uid);
+            Assert.Equal(anonymousUser.Uid, sut.CurrentUser.Uid);
+            Assert.False(linkedUser.IsAnonymous);
+            Assert.False(sut.CurrentUser.IsAnonymous);
+            Assert.Equal(email, linkedUser.Email);
+            Assert.Equal(email, sut.CurrentUser.Email);
         }
 
         [Fact]
@@ -160,6 +191,26 @@ namespace Plugin.Firebase.IntegrationTests.Auth
         }
 
         [Fact]
+        public async Task sends_password_reset_email_for_current_user()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var email = CreateUniqueEmail("pw-reset-current");
+            await sut.SignInWithEmailAndPasswordAsync(email, "123456");
+
+            await sut.SendPasswordResetEmailAsync();
+        }
+
+        [Fact]
+        public async Task sends_password_reset_email_for_explicit_email()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var email = CreateUniqueEmail("pw-reset-explicit");
+            await sut.SignInWithEmailAndPasswordAsync(email, "123456");
+
+            await sut.SendPasswordResetEmailAsync(email);
+        }
+
+        [Fact]
         public async Task reloads_current_user()
         {
             var sut = CrossFirebaseAuth.Current;
@@ -174,6 +225,34 @@ namespace Plugin.Firebase.IntegrationTests.Auth
         }
 
         [Fact]
+        public async Task invokes_auth_state_listener_on_sign_in_and_sign_out()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var email = CreateUniqueEmail("auth-state");
+            await sut.CreateUserAsync(email, "123456");
+            await sut.SignOutAsync();
+            var sawSignedIn = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var sawSignedOutAfterSignIn = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using var listener = sut.AddAuthStateListener(auth => {
+                if(auth.CurrentUser != null) {
+                    sawSignedIn.TrySetResult(true);
+                } else if(sawSignedIn.Task.IsCompleted) {
+                    sawSignedOutAfterSignIn.TrySetResult(true);
+                }
+            });
+
+            await sut.SignInWithEmailAndPasswordAsync(email, "123456", createsUserAutomatically: false);
+            await sawSignedIn.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            await sut.SignOutAsync();
+            await sawSignedOutAfterSignIn.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            await sut.SignInWithEmailAndPasswordAsync(email, "123456", createsUserAutomatically: false);
+            await sut.CurrentUser.DeleteAsync();
+        }
+
+        [Fact]
         public async Task sets_language_code()
         {
             var sut = CrossFirebaseAuth.Current;
@@ -184,6 +263,21 @@ namespace Plugin.Firebase.IntegrationTests.Auth
                 sut.UseAppLanguage();
             });
             Assert.Null(ex);
+        }
+
+        [Fact]
+        public async Task exposes_user_metadata_and_provider_infos_after_sign_in()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var email = CreateUniqueEmail("user-metadata");
+            var user = await sut.SignInWithEmailAndPasswordAsync(email, "123456");
+
+            Assert.False(string.IsNullOrWhiteSpace(user.ProviderId));
+            Assert.NotNull(user.ProviderInfos);
+            Assert.Contains(user.ProviderInfos, x => x.Email == email);
+            Assert.NotNull(user.Metadata);
+            Assert.NotEqual(default, user.Metadata.CreationDate);
+            Assert.NotEqual(default, user.Metadata.LastSignInDate);
         }
 
         [Fact]
@@ -208,6 +302,23 @@ namespace Plugin.Firebase.IntegrationTests.Auth
             Assert.True(idTokenResult.GetClaim<bool>("is_awesome"));
         }
 
+        [Fact]
+        public async Task exposes_id_token_metadata()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var email = CreateUniqueEmail("token-metadata");
+            var user = await sut.SignInWithEmailAndPasswordAsync(email, "123456");
+
+            var idTokenResult = await user.GetIdTokenResultAsync();
+
+            Assert.False(string.IsNullOrWhiteSpace(idTokenResult.Token));
+            Assert.NotNull(idTokenResult.Claims);
+            Assert.NotEmpty(idTokenResult.Claims);
+            Assert.NotEqual(default, idTokenResult.AuthDate);
+            Assert.NotEqual(default, idTokenResult.IssuedAtDate);
+            Assert.NotEqual(default, idTokenResult.ExpirationDate);
+        }
+
         public async Task DisposeAsync()
         {
             var sut = CrossFirebaseAuth.Current;
@@ -222,6 +333,11 @@ namespace Plugin.Firebase.IntegrationTests.Auth
             Assert.NotNull(exception.InnerException);
             Assert.False(string.IsNullOrWhiteSpace(exception.NativeExceptionTypeName));
             Assert.False(string.IsNullOrWhiteSpace(exception.NativeErrorMessage));
+        }
+
+        private static string CreateUniqueEmail(string prefix)
+        {
+            return $"{prefix}-{Guid.NewGuid():N}@test.com";
         }
     }
 }

--- a/tests/Plugin.Firebase.IntegrationTests/Crashlytics/CrashlyticsFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Crashlytics/CrashlyticsFixture.cs
@@ -1,0 +1,58 @@
+using Plugin.Firebase.Crashlytics;
+
+namespace Plugin.Firebase.IntegrationTests.Crashlytics
+{
+    [Collection("Sequential")]
+    [TestLogging]
+    [Preserve(AllMembers = true)]
+    public sealed class CrashlyticsFixture
+    {
+        [Fact]
+        public void configures_collection_and_custom_keys()
+        {
+            var sut = CrossFirebaseCrashlytics.Current;
+
+            sut.SetCrashlyticsCollectionEnabled(false);
+            sut.SetCustomKey("test_bool", true);
+            sut.SetCustomKey("test_int", 1);
+            sut.SetCustomKey("test_long", 2L);
+            sut.SetCustomKey("test_float", 3.5f);
+            sut.SetCustomKey("test_double", 4.5d);
+            sut.SetCustomKey("test_string", "value");
+            sut.SetCustomKeys(new Dictionary<string, object> {
+                { "bulk_bool", false },
+                { "bulk_int", 7 },
+                { "bulk_string", "bulk-value" }
+            });
+            sut.SetUserId($"integration-test-{Guid.NewGuid():N}");
+            sut.Log("Crashlytics integration smoke test");
+            sut.SetCrashlyticsCollectionEnabled(true);
+        }
+
+        [Fact]
+        public async Task records_exception_and_queries_unsent_reports()
+        {
+            if(OperatingSystem.IsIOS() && DeviceInfo.DeviceType == DeviceType.Virtual) {
+                return;
+            }
+
+            var sut = CrossFirebaseCrashlytics.Current;
+
+            sut.SetCrashlyticsCollectionEnabled(false);
+            sut.RecordException(new InvalidOperationException("Crashlytics integration smoke test"));
+            await sut.CheckForUnsentReportsAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            sut.SetCrashlyticsCollectionEnabled(true);
+        }
+
+        [Fact]
+        public void handles_unsent_report_controls()
+        {
+            var sut = CrossFirebaseCrashlytics.Current;
+
+            sut.SetCrashlyticsCollectionEnabled(false);
+            sut.SendUnsentReports();
+            sut.DeleteUnsentReports();
+            sut.SetCrashlyticsCollectionEnabled(true);
+        }
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -34,6 +34,40 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         }
 
         [Fact]
+        public async Task creates_document_with_auto_generated_reference()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var collection = GetTestingCollection(sut);
+            var document = collection.CreateDocument();
+            var item = new SimpleItem("generated-item");
+
+            await document.SetDataAsync(item);
+
+            var snapshot = await document.GetDocumentSnapshotAsync<SimpleItem>();
+            Assert.False(string.IsNullOrWhiteSpace(document.Id));
+            Assert.False(string.IsNullOrWhiteSpace(document.Path));
+            Assert.Equal(document.Id, snapshot.Reference.Id);
+            Assert.Equal(document.Id, snapshot.Data.Id);
+            Assert.Equal("generated-item", snapshot.Data.Title);
+        }
+
+        [Fact]
+        public async Task adds_document_with_auto_generated_id()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var collection = GetTestingCollection(sut);
+
+            var document = await collection.AddDocumentAsync(new SimpleItem("added-item"));
+
+            var snapshot = await document.GetDocumentSnapshotAsync<SimpleItem>();
+            Assert.False(string.IsNullOrWhiteSpace(document.Id));
+            Assert.False(string.IsNullOrWhiteSpace(document.Path));
+            Assert.Equal(document.Id, snapshot.Reference.Id);
+            Assert.Equal(document.Id, snapshot.Data.Id);
+            Assert.Equal("added-item", snapshot.Data.Title);
+        }
+
+        [Fact]
         public async Task sets_server_timestamp_via_property_attribute()
         {
             var sut = CrossFirebaseFirestore.Current;
@@ -197,6 +231,28 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         }
 
         [Fact]
+        public async Task uses_field_path_overloads()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var nestedFieldPath = FieldPath.Of(new[] { "first_sighting_location", "latitude" });
+
+            var nestedPathResults = await sut
+                .GetCollection("pokemons")
+                .WhereEqualsTo(nestedFieldPath, 52.5042112)
+                .GetDocumentsAsync<Pokemon>();
+
+            var documentIdResults = await sut
+                .GetCollection("pokemons")
+                .OrderBy(FieldPath.DocumentId())
+                .StartingAt("2")
+                .EndingAt("4")
+                .GetDocumentsAsync<Pokemon>();
+
+            Assert.Equal(9, nestedPathResults.Count);
+            Assert.Equal(new[] { "2", "3", "4" }, documentIdResults.Documents.Select(x => x.Data.Id));
+        }
+
+        [Fact]
         public async Task orders_and_limits_data()
         {
             var sut = CrossFirebaseFirestore.Current;
@@ -208,6 +264,20 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
                 .GetDocumentsAsync<Pokemon>();
 
             Assert.Equal(new[] { "Wartortle", "Venusaur", "Squirtle" }, pokemons.Documents.Select(x => x.Data.Name));
+        }
+
+        [Fact]
+        public async Task uses_limited_to_last()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+
+            var pokemons = await sut
+                .GetCollection("pokemons")
+                .OrderBy("name")
+                .LimitedToLast(3)
+                .GetDocumentsAsync<Pokemon>();
+
+            Assert.Equal(new[] { "Squirtle", "Venusaur", "Wartortle" }, pokemons.Documents.Select(x => x.Data.Name));
         }
 
         [Fact]
@@ -252,6 +322,34 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         }
 
         [Fact]
+        public async Task uses_snapshot_end_cursors()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var snapshot = await sut
+                .GetDocument("pokemons/7")
+                .GetDocumentSnapshotAsync<Pokemon>();
+
+            var endingAt = await sut
+                .GetCollection("pokemons")
+                .OrderBy("name")
+                .EndingAt(snapshot)
+                .GetDocumentsAsync<Pokemon>();
+
+            var endingBefore = await sut
+                .GetCollection("pokemons")
+                .OrderBy("name")
+                .EndingBefore(snapshot)
+                .GetDocumentsAsync<Pokemon>();
+
+            Assert.Equal(
+                new[] { "Blastoise", "Bulbasaur", "Charizard", "Charmander", "Charmeleon", "Ivysaur", "Squirtle" },
+                endingAt.Documents.Select(x => x.Data.Name));
+            Assert.Equal(
+                new[] { "Blastoise", "Bulbasaur", "Charizard", "Charmander", "Charmeleon", "Ivysaur" },
+                endingBefore.Documents.Select(x => x.Data.Name));
+        }
+
+        [Fact]
         public async Task sets_multiple_cursor_conditions()
         {
             var sut = CrossFirebaseFirestore.Current;
@@ -283,6 +381,23 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
 
             Assert.Equal(new[] { "1", "2", "3", "4", "5" }, firstPageSnapshot.Documents.Select(x => x.Data.Id));
             Assert.Equal(new[] { "6", "7", "8", "9" }, nextPageSnapshot.Documents.Select(x => x.Data.Id));
+        }
+
+        [Fact]
+        public async Task covers_query_snapshot_properties()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var snapshot = await sut
+                .GetCollection("pokemons")
+                .WhereEqualsTo("poke_type", PokeType.Fire)
+                .GetDocumentsAsync<Pokemon>();
+
+            Assert.False(snapshot.IsEmpty);
+            Assert.Equal(snapshot.Documents.Count(), snapshot.Count);
+            Assert.NotNull(snapshot.Query);
+            Assert.NotNull(snapshot.Metadata);
+            Assert.NotEmpty(snapshot.DocumentChanges);
+            Assert.NotEmpty(snapshot.GetDocumentChanges(includeMetadataChanges: false));
         }
 
         [Fact]
@@ -335,6 +450,119 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
 
             snapshot = await document.GetDocumentSnapshotAsync<Pokemon>();
             Assert.Equal(4, snapshot.Data.OtherProperties["colors"]);
+        }
+
+        [Fact]
+        public async Task covers_document_set_overloads_with_merge()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var mergedDictionaryDocument = GetTestingDocument(sut, "merge-dictionary");
+            var tupleDocument = GetTestingDocument(sut, "tuple-set");
+            var mergedTupleDocument = GetTestingDocument(sut, "merge-tuple");
+
+            await mergedDictionaryDocument.SetDataAsync(PokemonFactory.CreateCharmander());
+            await mergedDictionaryDocument.SetDataAsync(
+                new Dictionary<object, object> {
+                    { "name", "Merged Charmander" }
+                },
+                SetOptions.Merge());
+
+            await tupleDocument.SetDataAsync(
+                ("name", "Tuple Pokemon"),
+                ("sighting_count", 12L));
+
+            await mergedTupleDocument.SetDataAsync(PokemonFactory.CreateSquirtle());
+            await mergedTupleDocument.SetDataAsync(
+                SetOptions.Merge(),
+                ("name", "Merged Squirtle"));
+
+            var mergedDictionarySnapshot = await mergedDictionaryDocument.GetDocumentSnapshotAsync<Pokemon>();
+            var tupleSnapshot = await tupleDocument.GetDocumentSnapshotAsync<Pokemon>();
+            var mergedTupleSnapshot = await mergedTupleDocument.GetDocumentSnapshotAsync<Pokemon>();
+
+            Assert.Equal("Merged Charmander", mergedDictionarySnapshot.Data.Name);
+            Assert.Equal(60, mergedDictionarySnapshot.Data.HeightInCm);
+            Assert.Equal("Tuple Pokemon", tupleSnapshot.Data.Name);
+            Assert.Equal(12L, tupleSnapshot.Data.SightingCount);
+            Assert.Equal("Merged Squirtle", mergedTupleSnapshot.Data.Name);
+            Assert.Equal(50, mergedTupleSnapshot.Data.HeightInCm);
+        }
+
+        [Fact]
+        public async Task covers_batch_set_overloads_and_commit_local()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var mergedDictionaryDocument = GetTestingDocument(sut, "batch-merge-dictionary");
+            var tupleDocument = GetTestingDocument(sut, "batch-tuple");
+            var mergedTupleDocument = GetTestingDocument(sut, "batch-merge-tuple");
+
+            await mergedDictionaryDocument.SetDataAsync(PokemonFactory.CreateCharmander());
+            await mergedTupleDocument.SetDataAsync(PokemonFactory.CreateSquirtle());
+
+            var batch = sut.CreateBatch();
+            batch.SetData(
+                mergedDictionaryDocument,
+                new Dictionary<object, object> {
+                    { "name", "Batch Merged Charmander" }
+                },
+                SetOptions.Merge());
+            batch.SetData(
+                tupleDocument,
+                ("name", "Batch Tuple Pokemon"),
+                ("sighting_count", 33L));
+            batch.SetData(
+                mergedTupleDocument,
+                SetOptions.Merge(),
+                ("name", "Batch Merged Squirtle"));
+            batch.CommitLocal();
+
+            await sut.WaitForPendingWritesAsync();
+
+            var mergedDictionarySnapshot = await mergedDictionaryDocument.GetDocumentSnapshotAsync<Pokemon>();
+            var tupleSnapshot = await tupleDocument.GetDocumentSnapshotAsync<Pokemon>();
+            var mergedTupleSnapshot = await mergedTupleDocument.GetDocumentSnapshotAsync<Pokemon>();
+
+            Assert.Equal("Batch Merged Charmander", mergedDictionarySnapshot.Data.Name);
+            Assert.Equal(60, mergedDictionarySnapshot.Data.HeightInCm);
+            Assert.Equal("Batch Tuple Pokemon", tupleSnapshot.Data.Name);
+            Assert.Equal(33L, tupleSnapshot.Data.SightingCount);
+            Assert.Equal("Batch Merged Squirtle", mergedTupleSnapshot.Data.Name);
+            Assert.Equal(50, mergedTupleSnapshot.Data.HeightInCm);
+        }
+
+        [Fact]
+        public async Task covers_transaction_set_overloads()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var mergedDictionaryDocument = GetTestingDocument(sut, "transaction-merge-dictionary");
+            var mergedTupleDocument = GetTestingDocument(sut, "transaction-merge-tuple");
+
+            await mergedDictionaryDocument.SetDataAsync(PokemonFactory.CreateCharmander());
+            await mergedTupleDocument.SetDataAsync(PokemonFactory.CreateSquirtle());
+
+            await sut.RunTransactionAsync(transaction => {
+                transaction.SetData(
+                    mergedDictionaryDocument,
+                    new Dictionary<object, object> {
+                        { "name", "Transaction Merged Charmander" }
+                    },
+                    SetOptions.Merge());
+                transaction.SetData(
+                    mergedTupleDocument,
+                    SetOptions.Merge(),
+                    ("name", "Transaction Merged Squirtle"),
+                    ("sighting_count", 91L));
+                return true;
+            });
+
+            var mergedDictionarySnapshot = await mergedDictionaryDocument.GetDocumentSnapshotAsync<Pokemon>();
+            var mergedTupleSnapshot = await mergedTupleDocument.GetDocumentSnapshotAsync<Pokemon>();
+
+            Assert.Equal("Transaction Merged Charmander", mergedDictionarySnapshot.Data.Name);
+            Assert.Equal(60, mergedDictionarySnapshot.Data.HeightInCm);
+            Assert.Equal("Transaction Merged Squirtle", mergedTupleSnapshot.Data.Name);
+            Assert.Equal(91L, mergedTupleSnapshot.Data.SightingCount);
+            Assert.Equal(50, mergedTupleSnapshot.Data.HeightInCm);
         }
 
         [Fact]
@@ -787,6 +1015,51 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
             Assert.Equal("transaction-merge", transactionMergeResult.Writer);
             Assert.Equal(50L, transactionMergeResult.Count);
             Assert.Equal("kept-by-transaction-merge", transactionMergeResult.Untouched);
+        }
+
+        [Fact]
+        public async Task exposes_parent_relationships()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var parentDocument = GetTestingDocument(sut, "parent");
+            var subCollection = parentDocument.GetCollection("sub_items");
+            var childDocument = subCollection.GetDocument("child");
+
+            await parentDocument.SetDataAsync(new SimpleItem("parent"));
+            await childDocument.SetDataAsync(new SimpleItem("child"));
+
+            Assert.Equal(parentDocument.Path, subCollection.Parent.Path);
+            Assert.Equal(parentDocument.Path, childDocument.Parent.Parent.Path);
+            Assert.Equal(childDocument.Path, childDocument.Parent.GetDocument(childDocument.Id).Path);
+        }
+
+        [Fact]
+        public async Task queries_collection_group()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var marker = Guid.NewGuid().ToString("N");
+            var firstDocument = GetTestingDocument(sut, "group-parent-1")
+                .GetCollection("sub_items")
+                .GetDocument("first");
+            var secondDocument = GetTestingDocument(sut, "group-parent-2")
+                .GetCollection("sub_items")
+                .GetDocument("second");
+
+            await firstDocument.SetDataAsync(new SimpleItem($"{marker}-one"));
+            await secondDocument.SetDataAsync(new SimpleItem($"{marker}-two"));
+
+            var snapshot = await sut
+                .GetCollectionGroup("sub_items")
+                .GetDocumentsAsync<SimpleItem>();
+
+            var matchingTitles = snapshot.Documents
+                .Select(x => x.Data.Title)
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Where(x => x.StartsWith(marker, StringComparison.Ordinal))
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(new[] { $"{marker}-one", $"{marker}-two" }, matchingTitles);
         }
 
         public async Task DisposeAsync()

--- a/tests/Plugin.Firebase.IntegrationTests/Storage/StorageFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Storage/StorageFixture.cs
@@ -150,6 +150,20 @@ namespace Plugin.Firebase.IntegrationTests.Storage
             }
         }
 
+        [Fact]
+        public async Task uploads_via_file_path()
+        {
+            var path = "texts/via_file.txt";
+            var contents = "Some text via file";
+            var filePath = await CreateTempTextFileAsync("via_file.txt", contents);
+            var reference = CrossFirebaseStorage.Current.GetReferenceFromPath(path);
+
+            await reference.PutFile(filePath).AwaitAsync();
+
+            var bytes = await reference.GetBytesAsync(1 * 1024 * 1024);
+            Assert.Equal(contents, Encoding.UTF8.GetString(bytes));
+        }
+
         private static async Task<Stream> CreateTextStreamAsync(string text)
         {
             var stream = new MemoryStream();
@@ -157,6 +171,13 @@ namespace Plugin.Firebase.IntegrationTests.Storage
             await writer.WriteAsync(text);
             await writer.FlushAsync();
             return stream;
+        }
+
+        private static async Task<string> CreateTempTextFileAsync(string fileName, string text)
+        {
+            var filePath = Path.Combine(FileSystem.CacheDirectory, fileName);
+            await File.WriteAllTextAsync(filePath, text);
+            return filePath;
         }
 
         [Fact]
@@ -181,6 +202,29 @@ namespace Plugin.Firebase.IntegrationTests.Storage
             Assert.Equal(path, updatedMetadata.Path);
             Assert.Equal("text/html", updatedMetadata.ContentType);
             Assert.Equal(customData, updatedMetadata.CustomMetadata);
+        }
+
+        [Fact]
+        public async Task observes_upload_success_snapshot()
+        {
+            var path = "texts/upload_success_snapshot.txt";
+            var reference = CrossFirebaseStorage.Current.GetReferenceFromPath(path);
+            var transferTask = reference.PutBytes(Encoding.UTF8.GetBytes("Observe upload success"));
+            var completion = new TaskCompletionSource<IStorageTaskSnapshot>(TaskCreationOptions.RunContinuationsAsynchronously);
+            Action<IStorageTaskSnapshot> observer = snapshot => completion.TrySetResult(snapshot);
+            transferTask.AddObserver(StorageTaskStatus.Success, observer);
+
+            try {
+                await transferTask.AwaitAsync();
+                var snapshot = await completion.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+                Assert.NotNull(snapshot);
+                Assert.NotNull(snapshot.Metadata);
+                Assert.True(snapshot.TransferredUnitCount > 0);
+                Assert.InRange(snapshot.TransferredFraction, 0.99, 1.01);
+            } finally {
+                transferTask.RemoveObserver(observer);
+            }
         }
 
         [Fact]
@@ -239,6 +283,29 @@ namespace Plugin.Firebase.IntegrationTests.Storage
         }
 
         [Fact]
+        public async Task observes_download_success_snapshot()
+        {
+            var reference = CrossFirebaseStorage
+                .Current
+                .GetReferenceFromPath("files_to_keep/text_1.txt");
+            var destinationFilePath = Path.Combine(FileSystem.CacheDirectory, $"downloaded-{Guid.NewGuid():N}.txt");
+            var transferTask = reference.DownloadFile(destinationFilePath);
+            var completion = new TaskCompletionSource<IStorageTaskSnapshot>(TaskCreationOptions.RunContinuationsAsynchronously);
+            Action<IStorageTaskSnapshot> observer = snapshot => completion.TrySetResult(snapshot);
+            transferTask.AddObserver(StorageTaskStatus.Success, observer);
+
+            try {
+                await transferTask.AwaitAsync();
+                var snapshot = await completion.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+                Assert.NotNull(snapshot);
+                Assert.True(File.Exists(destinationFilePath));
+            } finally {
+                transferTask.RemoveObserver(observer);
+            }
+        }
+
+        [Fact]
         public void can_manage_files_upload()
         {
             var path = $"texts/managed.txt";
@@ -263,6 +330,25 @@ namespace Plugin.Firebase.IntegrationTests.Storage
             transferTask.Pause();
             transferTask.Resume();
             transferTask.Cancel();
+        }
+
+        [Fact]
+        public async Task metadata_exposes_reference_and_timestamps()
+        {
+            var path = "texts/metadata_properties.txt";
+            var reference = CrossFirebaseStorage.Current.GetReferenceFromPath(path);
+
+            await reference.PutBytes(Encoding.UTF8.GetBytes("metadata properties")).AwaitAsync();
+            var metadata = await reference.GetMetadataAsync();
+
+            Assert.Equal(GetExpectedBucket(), metadata.Bucket);
+            Assert.Equal("metadata_properties.txt", metadata.Name);
+            Assert.Equal(path, metadata.Path);
+            if(metadata.StorageReference != null) {
+                Assert.Equal(reference.FullPath, metadata.StorageReference.FullPath);
+            }
+            Assert.NotEqual(default, metadata.CreationTime);
+            Assert.NotEqual(default, metadata.UpdatedTime);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Expands the native integration test suite across Auth, Crashlytics, Firestore, and Storage. The branch also extends supporting platform conversion and update paths that the new scenarios exercise.

## Current status

This is still a draft branch. It was created before the current emulator-first integration harness landed on `development`, so it currently conflicts and needs to be rebased before review.

## Validation

- Draft branch; re-run the emulator-backed Android and iOS integration matrix after rebasing.
