### PR TITLE
XCode 26.3 + .NET SDK / workload 9.0.313

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "9.0.0",
+    "version": "9.0.313",
+    "workloadVersion": "9.0.313",
     "allowPrerelease": false,
     "rollForward": "latestMinor"
   }


### PR DESCRIPTION
## Summary

- Pin the repository SDK to .NET `9.0.313`.
- Pin the workload set to `9.0.313` so Android/iOS workload resolution matches the local Xcode 26.3 test environment.

## Why

Bumps us to XCode 26.3. Also needed to enable a bump to iOS deps 12.7.0

## Validation

- `dotnet restore tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-android`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false`
- iOS XHarness integration suite: 70 run, 69 passed, 0 failed, 1 skipped
- Android XHarness integration suite: 70 run, 69 passed, 0 failed, 1 skipped
