### PR TITLE
Update iOS Firebase bindings to 12.7

### DIFF
--- a/src/Analytics/Analytics.csproj
+++ b/src/Analytics/Analytics.csproj
@@ -85,7 +85,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="[12.5.0.4,)" />
+        <PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="[12.7.0,)" />
     </ItemGroup>
     
 </Project>

--- a/src/AppCheck/AppCheck.csproj
+++ b/src/AppCheck/AppCheck.csproj
@@ -88,7 +88,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.AppCheck" Version="12.5.0.4" />
+        <PackageReference Include="AdamE.Firebase.iOS.AppCheck" Version="[12.7.0,)" />
     </ItemGroup>
 
 </Project>

--- a/src/Auth/Auth.csproj
+++ b/src/Auth/Auth.csproj
@@ -85,7 +85,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="[12.5.0.4,)" />
+        <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="[12.7.0,)" />
     </ItemGroup>
     
 </Project>

--- a/src/CloudMessaging/CloudMessaging.csproj
+++ b/src/CloudMessaging/CloudMessaging.csproj
@@ -86,7 +86,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="[12.5.0.4,)" />
+        <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="[12.7.0,)" />
     </ItemGroup>
     
 </Project>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -75,7 +75,7 @@
 
     <!-- nuget packages -->
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-      <PackageReference Include="AdamE.Firebase.iOS.Core" Version="[12.5.0.4,)" />
+      <PackageReference Include="AdamE.Firebase.iOS.Core" Version="[12.7.0,)" />
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">

--- a/src/Crashlytics/Crashlytics.csproj
+++ b/src/Crashlytics/Crashlytics.csproj
@@ -90,7 +90,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.Crashlytics" Version="[12.5.0.4,)" />
+        <PackageReference Include="AdamE.Firebase.iOS.Crashlytics" Version="[12.7.0,)" />
     </ItemGroup>
 
 </Project>

--- a/src/Firestore/Firestore.csproj
+++ b/src/Firestore/Firestore.csproj
@@ -85,7 +85,7 @@
     </ItemGroup>
     
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="[12.5.0.4,)" />
+        <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="[12.7.0,)" />
     </ItemGroup>
     
 </Project>

--- a/src/Firestore/Platforms/iOS/FirebaseFirestoreImplementation.cs
+++ b/src/Firestore/Platforms/iOS/FirebaseFirestoreImplementation.cs
@@ -106,7 +106,7 @@ public sealed class FirebaseFirestoreImplementation : DisposableBase, IFirebaseF
     /// <inheritdoc/>
     public void UseEmulator(string host, int port)
     {
-        _firestore.UseEmulatorWithHost(host, (uint) port);
+        _firestore.UseEmulatorWithHost(host, port);
         Settings = new FirestoreSettings(Settings.Host);
     }
 

--- a/src/Functions/Functions.csproj
+++ b/src/Functions/Functions.csproj
@@ -85,7 +85,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.CloudFunctions" Version="[12.5.0.4,)" />
+        <PackageReference Include="AdamE.Firebase.iOS.CloudFunctions" Version="[12.7.0,)" />
     </ItemGroup>
     
 </Project>

--- a/src/Functions/Platforms/iOS/FirebaseFunctionsImplementation.cs
+++ b/src/Functions/Platforms/iOS/FirebaseFunctionsImplementation.cs
@@ -37,6 +37,6 @@ public sealed class FirebaseFunctionsImplementation : DisposableBase, IFirebaseF
     /// <inheritdoc/>
     public void UseEmulator(string host, int port)
     {
-        _functions.UseEmulatorOriginWithHost(host, (uint) port);
+        _functions.UseEmulatorWithHost(host, port);
     }
 }

--- a/src/RemoteConfig/RemoteConfig.csproj
+++ b/src/RemoteConfig/RemoteConfig.csproj
@@ -85,7 +85,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.RemoteConfig" Version="[12.5.0.4,)" />
+        <PackageReference Include="AdamE.Firebase.iOS.RemoteConfig" Version="[12.7.0,)" />
     </ItemGroup>
 
 </Project>

--- a/src/Storage/Platforms/iOS/FirebaseStorageImplementation.cs
+++ b/src/Storage/Platforms/iOS/FirebaseStorageImplementation.cs
@@ -40,6 +40,6 @@ public sealed class FirebaseStorageImplementation : DisposableBase, IFirebaseSto
     /// <inheritdoc/>
     public void UseEmulator(string host, int port)
     {
-        _instance.UseEmulatorWithHost(host, (uint) port);
+        _instance.UseEmulatorWithHost(host, port);
     }
 }

--- a/src/Storage/Storage.csproj
+++ b/src/Storage/Storage.csproj
@@ -85,7 +85,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-        <PackageReference Include="AdamE.Firebase.iOS.Storage" Version="[12.5.0.4,)" />
+        <PackageReference Include="AdamE.Firebase.iOS.Storage" Version="[12.7.0,)" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Updates all iOS Firebase binding package lower bounds to `AdamE.Firebase.iOS.*` 12.7.0 and adjusts the iOS Firestore, Functions, and Storage emulator calls for the current binding APIs.

## Stack

Stacked on #621 (`emulator-integration-tests`) so this PR's diff is limited to the iOS binding package references and API call updates.

## Validation

Current branch validation:
- `git diff --check origin/emulator-integration-tests..HEAD`
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj -c Release -f net9.0` -> 46 passed

Earlier validation on this change:
- `dotnet restore tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-android`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false`
- Android integration run: 70 tests run, 69 passed, 0 failed, 1 ignored
- iOS integration run: 70 tests run, 69 passed, 0 failed, 1 ignored
