### PR TITLE
Support Firestore GeoPoint list writes

### DIFF
--- a/src/Firestore/Platforms/Android/Extensions/JavaObjectExtensions.cs
+++ b/src/Firestore/Platforms/Android/Extensions/JavaObjectExtensions.cs
@@ -55,6 +55,8 @@ public static class JavaObjectExtensions
                 return x.ToJavaList();
             case DocumentReferenceWrapper x:
                 return x.Wrapped;
+            case GeoPoint x:
+                return new global::Firebase.Firestore.GeoPoint(x.Latitude, x.Longitude);
             case IFirestoreObject x:
                 return x.ToJavaObject();
             default:

--- a/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
@@ -204,6 +204,8 @@ public static class NSObjectExtensions
                 return x.ToNSDate();
             case FieldValue x:
                 return x.ToNative();
+            case Plugin.Firebase.Firestore.GeoPoint x:
+                return new global::Firebase.CloudFirestore.GeoPoint(x.Latitude, x.Longitude);
             case IList x:
                 return x.ToNSArray();
             case IDictionary x:

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -502,6 +502,25 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
             Assert.Single(snapshot2.Documents);
         }
 
+        [Fact]
+        public async Task writes_geopoint_values_inside_firestore_lists()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var document = GetTestingDocument(sut, "geopoint-list-values");
+            var expected = new[] {
+                new GeoPoint(10.5, 20.25),
+                new GeoPoint(-33.875, 151.2)
+            };
+
+            await document.SetDataAsync(new GeoPointListDocument(expected));
+
+            var result = (await document.GetDocumentSnapshotAsync<GeoPointListDocument>()).Data;
+            Assert.Equal(expected[0].Latitude, result.Locations[0].Latitude);
+            Assert.Equal(expected[0].Longitude, result.Locations[0].Longitude);
+            Assert.Equal(expected[1].Latitude, result.Locations[1].Latitude);
+            Assert.Equal(expected[1].Longitude, result.Locations[1].Longitude);
+        }
+
         public async Task DisposeAsync()
         {
             TestLog.Write($"[FIRESTORE CLEANUP START] {_testingCollectionPath}");
@@ -531,6 +550,23 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         private ICollectionReference GetTestingCollection(IFirebaseFirestore firestore)
         {
             return firestore.GetCollection(_testingCollectionPath);
+        }
+
+        [Preserve(AllMembers = true)]
+        private sealed class GeoPointListDocument : IFirestoreObject
+        {
+            public GeoPointListDocument()
+            {
+                // needed for firestore
+            }
+
+            public GeoPointListDocument(IList<GeoPoint> locations)
+            {
+                Locations = locations;
+            }
+
+            [FirestoreProperty("locations")]
+            public IList<GeoPoint> Locations { get; private set; }
         }
 
         private static async Task EnsureBasePokemonsSeededAsync()


### PR DESCRIPTION
## Summary

Fixes #423 by converting managed `GeoPoint` values to native Firestore GeoPoint objects in Android and iOS scalar conversion paths.

## Root cause

Both list converters serialize each list item through the platform scalar conversion helpers. Those helpers did not recognize managed `Plugin.Firebase.Firestore.GeoPoint`, so a GeoPoint inside a list could not be written.

## Validation

- `git diff --check`
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj -c Release -f net9.0 --no-restore`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Debug -f net9.0-android --no-restore`