### PR TITLE
Fix iOS nested dictionary writes

### DIFF
--- a/src/Firestore/Platforms/iOS/Extensions/DictionaryExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/DictionaryExtensions.cs
@@ -44,44 +44,7 @@ public static class DictionaryExtensions
         ref NSMutableDictionary<NSString, NSObject> nsDictionary
     )
     {
-        switch(pair.Value) {
-            case bool x:
-                nsDictionary.Add((NSString) pair.Key, new NSNumber(x));
-                break;
-            case double x:
-                nsDictionary.Add((NSString) pair.Key, new NSNumber(x));
-                break;
-            case float x:
-                nsDictionary.Add((NSString) pair.Key, new NSNumber(x));
-                break;
-            case long x:
-                nsDictionary.Add((NSString) pair.Key, new NSNumber(x));
-                break;
-            case int x:
-                nsDictionary.Add((NSString) pair.Key, new NSNumber(x));
-                break;
-            case short x:
-                nsDictionary.Add((NSString) pair.Key, new NSNumber(x));
-                break;
-            case string x:
-                nsDictionary.Add((NSString) pair.Key, new NSString(x));
-                break;
-            case NSObject x:
-                nsDictionary.Add((NSString) pair.Key, x);
-                break;
-            default:
-                if(pair.Value is Enum @enum) {
-                    nsDictionary.Add((NSString) pair.Key, new NSNumber(Convert.ToInt64(@enum)));
-                    break;
-                } else if(pair.Value == null) {
-                    nsDictionary.Add((NSString) pair.Key, new NSNull());
-                    break;
-                } else {
-                    throw new ArgumentException(
-                        $"Couldn't put object of type {pair.Value.GetType()} into NSDictionary"
-                    );
-                }
-        }
+        nsDictionary.Add((NSString) pair.Key, pair.Value.ToNSObject());
     }
 
     /// <summary>

--- a/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
@@ -192,6 +192,8 @@ public static class NSObjectExtensions
                 return new NSNumber(x);
             case long x:
                 return new NSNumber(x);
+            case short x:
+                return new NSNumber(x);
             case float x:
                 return new NSNumber(x);
             case double x:

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -502,6 +502,30 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
             Assert.Single(snapshot2.Documents);
         }
 
+        [Fact]
+        public async Task writes_nested_dictionary_properties_on_ios()
+        {
+            if(!OperatingSystem.IsIOS()) {
+                return;
+            }
+
+            var sut = CrossFirebaseFirestore.Current;
+            var document = GetTestingDocument(sut, "ios-nested-dictionary");
+            var expected = new Dictionary<string, Dictionary<string, short>> {
+                {
+                    "outer",
+                    new Dictionary<string, short> {
+                        { "inner", 7 }
+                    }
+                }
+            };
+
+            await document.SetDataAsync(new NestedShortDictionaryDocument(expected));
+
+            var snapshot = await document.GetDocumentSnapshotAsync<NestedShortDictionaryDocument>();
+            Assert.Equal((short) 7, snapshot.Data.Values["outer"]["inner"]);
+        }
+
         public async Task DisposeAsync()
         {
             TestLog.Write($"[FIRESTORE CLEANUP START] {_testingCollectionPath}");
@@ -531,6 +555,23 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         private ICollectionReference GetTestingCollection(IFirebaseFirestore firestore)
         {
             return firestore.GetCollection(_testingCollectionPath);
+        }
+
+        [Preserve(AllMembers = true)]
+        private sealed class NestedShortDictionaryDocument : IFirestoreObject
+        {
+            public NestedShortDictionaryDocument()
+            {
+                // needed for firestore
+            }
+
+            public NestedShortDictionaryDocument(Dictionary<string, Dictionary<string, short>> values)
+            {
+                Values = values;
+            }
+
+            [FirestoreProperty("values")]
+            public Dictionary<string, Dictionary<string, short>> Values { get; private set; }
         }
 
         private static async Task EnsureBasePokemonsSeededAsync()


### PR DESCRIPTION
## Summary

Fixes #526 by recursively converting nested dictionary values through the iOS NSObject conversion path.

## Root cause

The iOS non-generic dictionary conversion had a local scalar-only switch. Nested dictionaries were not passed through `ToNSObject()`, so supported nested map values failed with `Couldn't put object ... into NSDictionary`. The fix also keeps boxed `short` support explicit in `ToNSObject()`.

## Validation

- `git diff --check`
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj -c Release -f net9.0 --no-restore`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Debug -f net9.0-android --no-restore`