### PR TITLE
Fix Firestore SetData payload conversion

### DIFF
--- a/src/Firestore/Platforms/Android/Extensions/DictionaryExtensions.cs
+++ b/src/Firestore/Platforms/Android/Extensions/DictionaryExtensions.cs
@@ -114,6 +114,15 @@ public static class DictionaryExtensions
 
     public static HashMap ToHashMap(this object @this)
     {
+        switch(@this) {
+            case IDictionary<string, object?> stringDictionary:
+                return stringDictionary.ToHashMap();
+            case IDictionary<object, object?> objectDictionary:
+                return objectDictionary.ToHashMap();
+            case IDictionary dictionary:
+                return dictionary.ToHashMapFromNonGenericDict();
+        }
+
         var map = new HashMap();
         var properties = @this.GetType().GetProperties();
         foreach(var property in properties) {

--- a/src/Firestore/Platforms/iOS/Extensions/DictionaryExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/DictionaryExtensions.cs
@@ -91,6 +91,10 @@ public static class DictionaryExtensions
     /// <returns>A dictionary with property names as keys and their values.</returns>
     public static Dictionary<object, object?> ToDictionary(this object @this)
     {
+        if(@this is IDictionary dictionary) {
+            return dictionary.ToObjectDictionary();
+        }
+
         var dict = new Dictionary<object, object?>();
         var properties = @this.GetType().GetProperties();
         foreach(var property in properties) {
@@ -113,6 +117,25 @@ public static class DictionaryExtensions
                 var attribute = (FirestoreServerTimestampAttribute) timestampAttributes[0];
                 dict[attribute.PropertyName] = NativeFieldValue.ServerTimestamp;
             }
+        }
+        return dict;
+    }
+
+    internal static Dictionary<object, object?> ToDictionary(this IEnumerable<(object, object?)> @this)
+    {
+        var dict = new Dictionary<object, object?>();
+        foreach(var (key, value) in @this) {
+            dict[key] = value;
+        }
+        return dict;
+    }
+
+    private static Dictionary<object, object?> ToObjectDictionary(this IDictionary @this)
+    {
+        var dict = new Dictionary<object, object?>();
+        foreach(DictionaryEntry pair in @this) {
+            var key = pair.Key ?? throw new ArgumentException("Dictionary contains a null key.");
+            dict[key] = pair.Value;
         }
         return dict;
     }

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -502,6 +502,57 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
             Assert.Single(snapshot2.Documents);
         }
 
+        [Fact]
+        public async Task writes_set_data_from_dictionary_and_tuple_payloads()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+
+            var dictionaryDocument = GetTestingDocument(sut, "setdata-string-dictionary");
+            await dictionaryDocument.SetDataAsync(new Dictionary<string, object> {
+                { "field_a", "dictionary-a" },
+                { "field_b", "dictionary-b" }
+            });
+            var dictionaryResult = (await dictionaryDocument.GetDocumentSnapshotAsync<SetDataPayloadDocument>()).Data;
+            Assert.Equal("dictionary-a", dictionaryResult.FieldA);
+            Assert.Equal("dictionary-b", dictionaryResult.FieldB);
+
+            var tupleDocument = GetTestingDocument(sut, "setdata-tuple");
+            await tupleDocument.SetDataAsync(
+                ("field_a", "tuple-a"),
+                ("field_b", "tuple-b"));
+            var tupleResult = (await tupleDocument.GetDocumentSnapshotAsync<SetDataPayloadDocument>()).Data;
+            Assert.Equal("tuple-a", tupleResult.FieldA);
+            Assert.Equal("tuple-b", tupleResult.FieldB);
+
+            if(OperatingSystem.IsAndroid() is false) {
+                return;
+            }
+
+            var transactionDictionaryDocument = GetTestingDocument(sut, "transaction-setdata-string-dictionary");
+            var transactionTupleDocument = GetTestingDocument(sut, "transaction-setdata-tuple");
+            await sut.RunTransactionAsync(transaction => {
+                transaction.SetData(
+                    transactionDictionaryDocument,
+                    new Dictionary<string, object> {
+                        { "field_a", "transaction-dictionary-a" },
+                        { "field_b", "transaction-dictionary-b" }
+                    });
+                transaction.SetData(
+                    transactionTupleDocument,
+                    ("field_a", "transaction-tuple-a"),
+                    ("field_b", "transaction-tuple-b"));
+                return true;
+            });
+
+            var transactionDictionaryResult = (await transactionDictionaryDocument.GetDocumentSnapshotAsync<SetDataPayloadDocument>()).Data;
+            Assert.Equal("transaction-dictionary-a", transactionDictionaryResult.FieldA);
+            Assert.Equal("transaction-dictionary-b", transactionDictionaryResult.FieldB);
+
+            var transactionTupleResult = (await transactionTupleDocument.GetDocumentSnapshotAsync<SetDataPayloadDocument>()).Data;
+            Assert.Equal("transaction-tuple-a", transactionTupleResult.FieldA);
+            Assert.Equal("transaction-tuple-b", transactionTupleResult.FieldB);
+        }
+
         public async Task DisposeAsync()
         {
             TestLog.Write($"[FIRESTORE CLEANUP START] {_testingCollectionPath}");
@@ -531,6 +582,21 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         private ICollectionReference GetTestingCollection(IFirebaseFirestore firestore)
         {
             return firestore.GetCollection(_testingCollectionPath);
+        }
+
+        [Preserve(AllMembers = true)]
+        private sealed class SetDataPayloadDocument : IFirestoreObject
+        {
+            public SetDataPayloadDocument()
+            {
+                // needed for firestore
+            }
+
+            [FirestoreProperty("field_a")]
+            public string FieldA { get; private set; }
+
+            [FirestoreProperty("field_b")]
+            public string FieldB { get; private set; }
         }
 
         private static async Task EnsureBasePokemonsSeededAsync()


### PR DESCRIPTION
## Summary

Fixes #478 by treating `Dictionary<string, object>` and tuple SetData payloads as Firestore data maps instead of reflecting them as arbitrary objects.

## Root cause

The object conversion overloads did not recognize dictionary instances, and tuple arrays fell through to object reflection. That produced incorrect field maps for SetData calls.

## Validation

- `git diff --check`
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj -c Release -f net9.0 --no-restore`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Debug -f net9.0-android --no-restore`