### PR TITLE
Preserve iOS batch tuple SetOptions

### DIFF
--- a/src/Firestore/Platforms/iOS/Extensions/DictionaryExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/DictionaryExtensions.cs
@@ -193,4 +193,13 @@ public static class DictionaryExtensions
         }
         return dict;
     }
+
+    internal static Dictionary<object, object?> ToDictionary(this IEnumerable<(object, object?)> @this)
+    {
+        var dict = new Dictionary<object, object?>();
+        foreach(var (key, value) in @this) {
+            dict[key] = value;
+        }
+        return dict;
+    }
 }

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -502,6 +502,33 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
             Assert.Single(snapshot2.Documents);
         }
 
+        [Fact]
+        public async Task applies_ios_batch_tuple_set_options()
+        {
+            if(OperatingSystem.IsIOS() is false) {
+                return;
+            }
+
+            var sut = CrossFirebaseFirestore.Current;
+            var document = GetTestingDocument(sut, "ios-batch-tuple-set-options");
+            await document.SetDataAsync(new Dictionary<object, object> {
+                { "untouched", "keep" },
+                { "selected", "old" }
+            });
+
+            var batch = sut.CreateBatch();
+            batch.SetData(
+                document,
+                SetOptions.MergeFields("selected"),
+                ("selected", "from-batch"),
+                ("untouched", "should-not-change"));
+            await batch.CommitAsync();
+
+            var result = (await document.GetDocumentSnapshotAsync<BatchMergeFieldsDocument>()).Data;
+            Assert.Equal("keep", result.Untouched);
+            Assert.Equal("from-batch", result.Selected);
+        }
+
         public async Task DisposeAsync()
         {
             TestLog.Write($"[FIRESTORE CLEANUP START] {_testingCollectionPath}");
@@ -531,6 +558,21 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         private ICollectionReference GetTestingCollection(IFirebaseFirestore firestore)
         {
             return firestore.GetCollection(_testingCollectionPath);
+        }
+
+        [Preserve(AllMembers = true)]
+        private sealed class BatchMergeFieldsDocument : IFirestoreObject
+        {
+            public BatchMergeFieldsDocument()
+            {
+                // needed for firestore
+            }
+
+            [FirestoreProperty("untouched")]
+            public string Untouched { get; private set; }
+
+            [FirestoreProperty("selected")]
+            public string Selected { get; private set; }
         }
 
         private static async Task EnsureBasePokemonsSeededAsync()


### PR DESCRIPTION
## Summary

Fixes #625 by forwarding `SetOptions` from the iOS write batch tuple `SetData` overload.

## Root cause

`WriteBatchWrapper.SetData(IDocumentReference, SetOptions, params (object, object)[])` discarded the supplied options when delegating to the dictionary overload, so merge field masks were not applied.

## Validation

- `git diff --check`
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj -c Release -f net9.0 --no-restore`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Debug -f net9.0-android --no-restore`