### PR TITLE
Fix iOS write wrapper dictionary conversion

### DIFF
--- a/src/Firestore/Platforms/iOS/CollectionReferenceWrapper.cs
+++ b/src/Firestore/Platforms/iOS/CollectionReferenceWrapper.cs
@@ -36,9 +36,10 @@ public sealed class CollectionReferenceWrapper : QueryWrapper, ICollectionRefere
     /// <inheritdoc/>
     public async Task<IDocumentReference> AddDocumentAsync(object data)
     {
+        var nativeData = data.ToDictionary().ToNSObjectDictionary();
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var documentReference = _wrapped.AddDocument(
-            data.ToDictionary().ToNSObjectDictionary(),
+            nativeData,
             error => {
                 if(error == null) {
                     tcs.TrySetResult();

--- a/src/Firestore/Platforms/iOS/Extensions/DictionaryExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/DictionaryExtensions.cs
@@ -91,6 +91,10 @@ public static class DictionaryExtensions
     /// <returns>A dictionary with property names as keys and their values.</returns>
     public static Dictionary<object, object?> ToDictionary(this object @this)
     {
+        if(@this is IDictionary dictionary) {
+            return dictionary.ToObjectDictionary();
+        }
+
         var dict = new Dictionary<object, object?>();
         var properties = @this.GetType().GetProperties();
         foreach(var property in properties) {
@@ -113,6 +117,16 @@ public static class DictionaryExtensions
                 var attribute = (FirestoreServerTimestampAttribute) timestampAttributes[0];
                 dict[attribute.PropertyName] = NativeFieldValue.ServerTimestamp;
             }
+        }
+        return dict;
+    }
+
+    private static Dictionary<object, object?> ToObjectDictionary(this IDictionary @this)
+    {
+        var dict = new Dictionary<object, object?>();
+        foreach(DictionaryEntry pair in @this) {
+            var key = pair.Key ?? throw new ArgumentException("Dictionary contains a null key.");
+            dict[key] = pair.Value;
         }
         return dict;
     }

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -502,6 +502,111 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
             Assert.Single(snapshot2.Documents);
         }
 
+        [Fact]
+        public async Task writes_ios_dictionary_data_through_non_document_wrappers()
+        {
+            if(OperatingSystem.IsIOS() is false) {
+                return;
+            }
+
+            var sut = CrossFirebaseFirestore.Current;
+            var collection = GetTestingCollection(sut);
+
+            var addedDocument = await collection.AddDocumentAsync(new Dictionary<object, object> {
+                { "writer", "collection-add" },
+                { "count", 1L }
+            });
+            var addedResult = (await addedDocument.GetDocumentSnapshotAsync<WriteWrapperDictionaryDocument>()).Data;
+            Assert.Equal("collection-add", addedResult.Writer);
+            Assert.Equal(1L, addedResult.Count);
+
+            var batchSetDocument = collection.GetDocument("ios-batch-set-dictionary");
+            var batchUpdateDocument = collection.GetDocument("ios-batch-update-dictionary");
+            await batchUpdateDocument.SetDataAsync(new Dictionary<object, object> { { "writer", "seed" } });
+            var batch = sut.CreateBatch();
+            batch.SetData(batchSetDocument, new Dictionary<object, object> {
+                { "writer", "batch-set" },
+                { "count", 2L }
+            });
+            batch.UpdateData(batchUpdateDocument, new Dictionary<object, object> {
+                { "writer", "batch-update" },
+                { "count", 3L }
+            });
+            await batch.CommitAsync();
+
+            var batchSetResult = (await batchSetDocument.GetDocumentSnapshotAsync<WriteWrapperDictionaryDocument>()).Data;
+            Assert.Equal("batch-set", batchSetResult.Writer);
+            Assert.Equal(2L, batchSetResult.Count);
+
+            var batchUpdateResult = (await batchUpdateDocument.GetDocumentSnapshotAsync<WriteWrapperDictionaryDocument>()).Data;
+            Assert.Equal("batch-update", batchUpdateResult.Writer);
+            Assert.Equal(3L, batchUpdateResult.Count);
+
+            var batchMergeDocument = collection.GetDocument("ios-batch-merge-dictionary");
+            await batchMergeDocument.SetDataAsync(new Dictionary<object, object> {
+                { "writer", "seed" },
+                { "count", 30L },
+                { "untouched", "kept-by-batch-merge" }
+            });
+            var mergeBatch = sut.CreateBatch();
+            mergeBatch.SetData(
+                batchMergeDocument,
+                new Dictionary<object, object> { { "writer", "batch-merge" } },
+                SetOptions.Merge()
+            );
+            await mergeBatch.CommitAsync();
+
+            var batchMergeResult = (await batchMergeDocument.GetDocumentSnapshotAsync<WriteWrapperDictionaryDocument>()).Data;
+            Assert.Equal("batch-merge", batchMergeResult.Writer);
+            Assert.Equal(30L, batchMergeResult.Count);
+            Assert.Equal("kept-by-batch-merge", batchMergeResult.Untouched);
+
+            var transactionSetDocument = collection.GetDocument("ios-transaction-set-dictionary");
+            var transactionUpdateDocument = collection.GetDocument("ios-transaction-update-dictionary");
+            await transactionUpdateDocument.SetDataAsync(new Dictionary<object, object> { { "writer", "seed" } });
+            await sut.RunTransactionAsync(transaction => {
+                transaction.GetDocument<WriteWrapperDictionaryDocument>(transactionUpdateDocument);
+                transaction.SetData(transactionSetDocument, new Dictionary<object, object> {
+                    { "writer", "transaction-set" },
+                    { "count", 4L }
+                });
+                transaction.UpdateData(transactionUpdateDocument, new Dictionary<object, object> {
+                    { "writer", "transaction-update" },
+                    { "count", 5L }
+                });
+                return true;
+            });
+
+            var transactionSetResult = (await transactionSetDocument.GetDocumentSnapshotAsync<WriteWrapperDictionaryDocument>()).Data;
+            Assert.Equal("transaction-set", transactionSetResult.Writer);
+            Assert.Equal(4L, transactionSetResult.Count);
+
+            var transactionUpdateResult = (await transactionUpdateDocument.GetDocumentSnapshotAsync<WriteWrapperDictionaryDocument>()).Data;
+            Assert.Equal("transaction-update", transactionUpdateResult.Writer);
+            Assert.Equal(5L, transactionUpdateResult.Count);
+
+            var transactionMergeDocument = collection.GetDocument("ios-transaction-merge-dictionary");
+            await transactionMergeDocument.SetDataAsync(new Dictionary<object, object> {
+                { "writer", "seed" },
+                { "count", 50L },
+                { "untouched", "kept-by-transaction-merge" }
+            });
+            await sut.RunTransactionAsync(transaction => {
+                transaction.GetDocument<WriteWrapperDictionaryDocument>(transactionMergeDocument);
+                transaction.SetData(
+                    transactionMergeDocument,
+                    new Dictionary<object, object> { { "writer", "transaction-merge" } },
+                    SetOptions.Merge()
+                );
+                return true;
+            });
+
+            var transactionMergeResult = (await transactionMergeDocument.GetDocumentSnapshotAsync<WriteWrapperDictionaryDocument>()).Data;
+            Assert.Equal("transaction-merge", transactionMergeResult.Writer);
+            Assert.Equal(50L, transactionMergeResult.Count);
+            Assert.Equal("kept-by-transaction-merge", transactionMergeResult.Untouched);
+        }
+
         public async Task DisposeAsync()
         {
             TestLog.Write($"[FIRESTORE CLEANUP START] {_testingCollectionPath}");
@@ -531,6 +636,24 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         private ICollectionReference GetTestingCollection(IFirebaseFirestore firestore)
         {
             return firestore.GetCollection(_testingCollectionPath);
+        }
+
+        [Preserve(AllMembers = true)]
+        private sealed class WriteWrapperDictionaryDocument : IFirestoreObject
+        {
+            public WriteWrapperDictionaryDocument()
+            {
+                // needed for firestore
+            }
+
+            [FirestoreProperty("writer")]
+            public string Writer { get; private set; }
+
+            [FirestoreProperty("count")]
+            public long Count { get; private set; }
+
+            [FirestoreProperty("untouched")]
+            public string Untouched { get; private set; }
         }
 
         private static async Task EnsureBasePokemonsSeededAsync()


### PR DESCRIPTION
## Summary

Fixes #623 by converting dictionary payloads to native NSObject dictionaries before iOS collection, batch, and transaction write wrappers call native Firestore APIs.

## Root cause

Some iOS write wrappers accepted managed `Dictionary<object, object>` data but passed it directly to native Firestore APIs instead of using the same NSObject value conversion as document writes.

## Validation

- `git diff --check`
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj -c Release -f net9.0 --no-restore`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Debug -f net9.0-android --no-restore`