### PR TITLE
Preserve iOS batch tuple SetOptions

### DIFF
--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -657,6 +657,33 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
             Assert.Equal((short) 7, snapshot.Data.Values["outer"]["inner"]);
         }
 
+        [Fact]
+        public async Task applies_ios_batch_tuple_set_options()
+        {
+            if(OperatingSystem.IsIOS() is false) {
+                return;
+            }
+
+            var sut = CrossFirebaseFirestore.Current;
+            var document = GetTestingDocument(sut, "ios-batch-tuple-set-options");
+            await document.SetDataAsync(new Dictionary<object, object> {
+                { "untouched", "keep" },
+                { "selected", "old" }
+            });
+
+            var batch = sut.CreateBatch();
+            batch.SetData(
+                document,
+                SetOptions.MergeFields("selected"),
+                ("selected", "from-batch"),
+                ("untouched", "should-not-change"));
+            await batch.CommitAsync();
+
+            var result = (await document.GetDocumentSnapshotAsync<BatchMergeFieldsDocument>()).Data;
+            Assert.Equal("keep", result.Untouched);
+            Assert.Equal("from-batch", result.Selected);
+        }
+
         public async Task DisposeAsync()
         {
             TestLog.Write($"[FIRESTORE CLEANUP START] {_testingCollectionPath}");
@@ -770,6 +797,21 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
 
             [FirestoreProperty("values")]
             public Dictionary<string, Dictionary<string, short>> Values { get; private set; }
+        }
+
+        [Preserve(AllMembers = true)]
+        private sealed class BatchMergeFieldsDocument : IFirestoreObject
+        {
+            public BatchMergeFieldsDocument()
+            {
+                // needed for firestore
+            }
+
+            [FirestoreProperty("untouched")]
+            public string Untouched { get; private set; }
+
+            [FirestoreProperty("selected")]
+            public string Selected { get; private set; }
         }
 
         private static async Task EnsureBasePokemonsSeededAsync()


### PR DESCRIPTION
## Summary

Fixes #625 by forwarding `SetOptions` from the iOS write batch tuple `SetData` overload.

This replaces closed PR #634, which remained based on the temporary `firestore-nullable` branch.

## Root cause

`WriteBatchWrapper.SetData(IDocumentReference, SetOptions, params (object, object?)[])` discarded the supplied options when delegating to the dictionary overload, so merge field masks were not applied.

## Validation

- `git diff --check origin/development`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Release -f net9.0-android --no-restore`

Android build passed with the existing Core nullable warning in `CrossFirebase.cs`.
