### PR TITLE
Fix Android typed Firestore collection conversion

### DIFF
--- a/src/Firestore/Platforms/Android/Extensions/JavaObjectExtensions.cs
+++ b/src/Firestore/Platforms/Android/Extensions/JavaObjectExtensions.cs
@@ -100,15 +100,15 @@ public static class JavaObjectExtensions
             case Java.Lang.ICharSequence x:
                 return x.ToString();
             case Java.Lang.Boolean x:
-                return x.BooleanValue();
+                return x.BooleanValue().ConvertToTargetType(targetType);
             case Java.Lang.Integer x:
-                return x.IntValue();
+                return x.IntValue().ConvertToTargetType(targetType);
             case Java.Lang.Double x:
-                return x.DoubleValue();
+                return x.DoubleValue().ConvertToTargetType(targetType);
             case Java.Lang.Float x:
-                return x.FloatValue();
+                return x.FloatValue().ConvertToTargetType(targetType);
             case Java.Lang.Long x:
-                return x.LongValue();
+                return x.LongValue().ConvertToTargetType(targetType);
             case Date x:
                 return x.ToDateTimeOffset();
             case NativeFirebase.Timestamp x:
@@ -151,12 +151,12 @@ public static class JavaObjectExtensions
         }
 
         foreach(DictionaryEntry pair in @this) {
-            var key = pair.Key.ToJavaObject().ToObject(keyType);
+            var key = ConvertToObject(keyType, pair.Key);
             if(key is null) {
                 throw new ArgumentException("Dictionary contains a null key.");
             }
 
-            var value = pair.Value.ToJavaObject().ToObject(valueType);
+            var value = ConvertToObject(valueType, pair.Value);
             dict[key] = value;
         }
         return dict;
@@ -226,6 +226,23 @@ public static class JavaObjectExtensions
             }
         }
         return instance;
+    }
+
+    private static object? ConvertToObject(Type? targetType, object? value)
+    {
+        var conversionType = targetType.GetConversionType();
+
+        if(value == null) {
+            return null;
+        } else if(conversionType == typeof(string)) {
+            return value is Java.Lang.ICharSequence charSequence
+                ? charSequence.ToString()
+                : value.ToString();
+        } else if(value is Java.Lang.Object javaValue) {
+            return javaValue.ToObject(targetType);
+        }
+
+        return value.ConvertToTargetType(targetType);
     }
 
     public static IDictionary<string, object?> ToDictionary(this ArrayMap @this)

--- a/src/Firestore/Platforms/Android/Extensions/ListExtensions.cs
+++ b/src/Firestore/Platforms/Android/Extensions/ListExtensions.cs
@@ -18,26 +18,31 @@ public static class ListExtensions
         for(var i = 0; i < @this.Size(); i++) {
             var value = @this[i];
             if(value is Java.Lang.Object javaValue) {
-                list.Add(javaValue.ToObject(targetType));
+                list.AddConvertedValue(javaValue.ToObject(targetType), targetType);
             } else if(targetType == typeof(string)) {
-                list.Add(Convert.ToString(value));
+                list.AddConvertedValue(Convert.ToString(value), targetType);
             } else if(targetType == typeof(int)) {
-                list.Add(Convert.ToInt32(value));
+                list.AddConvertedValue(Convert.ToInt32(value), targetType);
             } else if(targetType == typeof(long)) {
-                list.Add(Convert.ToInt64(value));
+                list.AddConvertedValue(Convert.ToInt64(value), targetType);
             } else if(targetType == typeof(float)) {
-                list.Add(Convert.ToSingle(value));
+                list.AddConvertedValue(Convert.ToSingle(value), targetType);
             } else if(targetType == typeof(double)) {
-                list.Add(Convert.ToDouble(value));
+                list.AddConvertedValue(Convert.ToDouble(value), targetType);
             } else if(targetType == typeof(decimal)) {
-                list.Add(Convert.ToDecimal(value));
+                list.AddConvertedValue(Convert.ToDecimal(value), targetType);
             } else if(targetType == typeof(bool)) {
-                list.Add(Convert.ToBoolean(value));
+                list.AddConvertedValue(Convert.ToBoolean(value), targetType);
             } else {
-                list.Add(value);
+                list.AddConvertedValue(value, targetType);
             }
         }
         return list;
+    }
+
+    private static void AddConvertedValue(this IList list, object? value, Type? targetType)
+    {
+        list.Add(value.ConvertToTargetType(targetType));
     }
 
     public static JavaList ToJavaList(this IEnumerable @this)

--- a/src/Firestore/Platforms/Android/Extensions/TargetTypeConversionExtensions.cs
+++ b/src/Firestore/Platforms/Android/Extensions/TargetTypeConversionExtensions.cs
@@ -1,0 +1,25 @@
+namespace Plugin.Firebase.Firestore.Platforms.Android.Extensions;
+
+internal static class TargetTypeConversionExtensions
+{
+    public static Type? GetConversionType(this Type? targetType)
+    {
+        return targetType == null
+            ? null
+            : Nullable.GetUnderlyingType(targetType) ?? targetType;
+    }
+
+    public static object? ConvertToTargetType(this object? value, Type? targetType)
+    {
+        var conversionType = targetType.GetConversionType();
+        if(value == null || conversionType == null || conversionType == typeof(object) || conversionType.IsInstanceOfType(value)) {
+            return value;
+        }
+
+        if(conversionType.IsEnum) {
+            return Enum.ToObject(conversionType, value);
+        }
+
+        return Convert.ChangeType(value, conversionType);
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -547,6 +547,42 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         }
 
         [Fact]
+        public async Task reads_android_typed_numeric_collection_values()
+        {
+            if(!OperatingSystem.IsAndroid()) {
+                return;
+            }
+
+            var sut = CrossFirebaseFirestore.Current;
+            var document = GetTestingDocument(sut, "android-typed-numeric-collections");
+            await document.SetDataAsync(new Dictionary<object, object> {
+                {
+                    "counts",
+                    new Dictionary<object, object> {
+                        { "one", 1L },
+                        { "two", 2L }
+                    }
+                },
+                { "nullable_counts", new object[] { 1L, null, 3L } },
+                {
+                    "types",
+                    new Dictionary<object, object> {
+                        { "fire", PokeType.Fire },
+                        { "water", PokeType.Water }
+                    }
+                }
+            });
+
+            var snapshot = await document.GetDocumentSnapshotAsync<AndroidNumericCollectionsDocument>();
+
+            Assert.Equal(1, snapshot.Data.Counts["one"]);
+            Assert.Equal(2, snapshot.Data.Counts["two"]);
+            Assert.Equal(new int?[] { 1, null, 3 }, snapshot.Data.NullableCounts);
+            Assert.Equal(PokeType.Fire, snapshot.Data.Types["fire"]);
+            Assert.Equal(PokeType.Water, snapshot.Data.Types["water"]);
+        }
+
+        [Fact]
         public async Task writes_nested_dictionary_properties_on_ios()
         {
             if(!OperatingSystem.IsIOS()) {
@@ -633,6 +669,24 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
 
             [FirestoreProperty("values")]
             public Dictionary<string, PokeType> Values { get; private set; }
+        }
+
+        [Preserve(AllMembers = true)]
+        private sealed class AndroidNumericCollectionsDocument : IFirestoreObject
+        {
+            public AndroidNumericCollectionsDocument()
+            {
+                // needed for firestore
+            }
+
+            [FirestoreProperty("counts")]
+            public Dictionary<string, int> Counts { get; private set; }
+
+            [FirestoreProperty("nullable_counts")]
+            public IList<int?> NullableCounts { get; private set; }
+
+            [FirestoreProperty("types")]
+            public Dictionary<string, PokeType> Types { get; private set; }
         }
 
         [Preserve(AllMembers = true)]


### PR DESCRIPTION
## Summary

Fixes #610 by coercing Android Firestore Java primitive wrappers to the declared CLR target type before inserting values into generic dictionaries and lists.

This replaces closed PR #632, which remained based on the temporary `firestore-nullable` branch.

## Root cause

The Android conversion path returned wrapper values as their default CLR type, such as `long`, even when the target collection required `int`, nullable numeric values, or enum values. Assigning those values into generic collections could throw at runtime.

## Validation

- `git diff --check origin/development`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Release -f net9.0-android --no-restore`

Android build passed with the existing Core nullable warning in `CrossFirebase.cs`.
