### PR TITLE
Fix iOS enum dictionary conversion

### DIFF
--- a/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
@@ -132,7 +132,12 @@ public static class NSObjectExtensions
             return @this.ToUntypedObject();
         }
 
-        switch(Type.GetTypeCode(Nullable.GetUnderlyingType(targetType) ?? targetType)) {
+        var conversionType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        if(conversionType.IsEnum) {
+            return Enum.ToObject(conversionType, @this.Int64Value);
+        }
+
+        switch(Type.GetTypeCode(conversionType)) {
             case TypeCode.Boolean:
                 return @this.BoolValue;
             case TypeCode.Char:

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -526,6 +526,27 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         }
 
         [Fact]
+        public async Task reads_ios_enum_dictionary_values()
+        {
+            if(!OperatingSystem.IsIOS()) {
+                return;
+            }
+
+            var sut = CrossFirebaseFirestore.Current;
+            var document = GetTestingDocument(sut, "ios-enum-dictionary-values");
+            await document.SetDataAsync(new EnumDictionaryDocument(
+                new Dictionary<string, PokeType> {
+                    { "fire", PokeType.Fire },
+                    { "water", PokeType.Water }
+                }));
+
+            var snapshot = await document.GetDocumentSnapshotAsync<EnumDictionaryDocument>();
+
+            Assert.Equal(PokeType.Fire, snapshot.Data.Values["fire"]);
+            Assert.Equal(PokeType.Water, snapshot.Data.Values["water"]);
+        }
+
+        [Fact]
         public async Task writes_nested_dictionary_properties_on_ios()
         {
             if(!OperatingSystem.IsIOS()) {
@@ -595,6 +616,23 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
 
             [FirestoreProperty("values")]
             public Dictionary<string, object> Values { get; private set; }
+        }
+
+        [Preserve(AllMembers = true)]
+        private sealed class EnumDictionaryDocument : IFirestoreObject
+        {
+            public EnumDictionaryDocument()
+            {
+                // needed for firestore
+            }
+
+            public EnumDictionaryDocument(Dictionary<string, PokeType> values)
+            {
+                Values = values;
+            }
+
+            [FirestoreProperty("values")]
+            public Dictionary<string, PokeType> Values { get; private set; }
         }
 
         [Preserve(AllMembers = true)]


### PR DESCRIPTION
## Summary

Fixes #622 by converting iOS Firestore `NSNumber` values into enum target types when deserializing typed dictionaries.

This replaces closed PR #631, which remained based on the temporary `firestore-nullable` branch.

## Root cause

`NSNumber.ToObject(Type)` only handled primitive numeric target types. When a dictionary value type was an enum, conversion fell through instead of constructing the enum from the numeric backing value.

## Validation

- `git diff --check origin/development`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Release -f net9.0-android --no-restore`

Android build passed with the existing Core nullable warning in `CrossFirebase.cs`.
