### PR TITLE
Fix iOS dictionary object value conversion

### DIFF
--- a/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
@@ -128,8 +128,8 @@ public static class NSObjectExtensions
     /// <returns>The converted numeric value.</returns>
     public static object? ToObject(this NSNumber @this, Type? targetType = null)
     {
-        if(targetType == null) {
-            return @this.Int32Value;
+        if(targetType == null || targetType == typeof(object)) {
+            return @this.ToUntypedObject();
         }
 
         switch(Type.GetTypeCode(Nullable.GetUnderlyingType(targetType) ?? targetType)) {
@@ -159,6 +159,37 @@ public static class NSObjectExtensions
                 return @this.DoubleValue;
             default:
                 return null;
+        }
+    }
+
+    private static object ToUntypedObject(this NSNumber @this)
+    {
+        switch(@this.ObjCType) {
+            case "B":
+            case "c":
+                return @this.BoolValue;
+            case "C":
+                return @this.ByteValue;
+            case "s":
+                return @this.Int16Value;
+            case "S":
+                return @this.UInt16Value;
+            case "i":
+                return @this.Int32Value;
+            case "I":
+                return @this.UInt32Value;
+            case "q":
+            case "l":
+                return @this.Int64Value;
+            case "Q":
+            case "L":
+                return @this.UInt64Value;
+            case "f":
+                return @this.FloatValue;
+            case "d":
+                return @this.DoubleValue;
+            default:
+                return @this.Int64Value;
         }
     }
 

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -502,6 +502,29 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
             Assert.Single(snapshot2.Documents);
         }
 
+        [Fact]
+        public async Task reads_ios_dictionary_object_numeric_and_boolean_values()
+        {
+            if(!OperatingSystem.IsIOS()) {
+                return;
+            }
+
+            var sut = CrossFirebaseFirestore.Current;
+            var document = GetTestingDocument(sut, "ios-dictionary-object-values");
+            await document.SetDataAsync(new DictionaryObjectValuesDocument(
+                new Dictionary<string, object> {
+                    { "enabled", true },
+                    { "count", 5L },
+                    { "ratio", 1.25 }
+                }));
+
+            var snapshot = await document.GetDocumentSnapshotAsync<DictionaryObjectValuesDocument>();
+
+            Assert.True((bool) snapshot.Data.Values["enabled"]);
+            Assert.Equal(5L, Convert.ToInt64(snapshot.Data.Values["count"]));
+            Assert.Equal(1.25, Convert.ToDouble(snapshot.Data.Values["ratio"]));
+        }
+
         public async Task DisposeAsync()
         {
             TestLog.Write($"[FIRESTORE CLEANUP START] {_testingCollectionPath}");
@@ -531,6 +554,23 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         private ICollectionReference GetTestingCollection(IFirebaseFirestore firestore)
         {
             return firestore.GetCollection(_testingCollectionPath);
+        }
+
+        [Preserve(AllMembers = true)]
+        private sealed class DictionaryObjectValuesDocument : IFirestoreObject
+        {
+            public DictionaryObjectValuesDocument()
+            {
+                // needed for firestore
+            }
+
+            public DictionaryObjectValuesDocument(Dictionary<string, object> values)
+            {
+                Values = values;
+            }
+
+            [FirestoreProperty("values")]
+            public Dictionary<string, object> Values { get; private set; }
         }
 
         private static async Task EnsureBasePokemonsSeededAsync()


### PR DESCRIPTION
## Summary

Fixes #319 by materializing iOS `NSNumber` values when a Firestore dictionary target value type is `object`.

This replaces closed PR #630, which remained based on the temporary `firestore-nullable` branch.

## Root cause

`NSNumber.ToObject(typeof(object))` fell through the typed numeric switch and returned `null`, so values like bools, integers, and doubles inside `Dictionary<string, object>` properties were lost on iOS reads.

## Validation

- `git diff --check origin/development`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Release -f net9.0-android --no-restore`

Android build passed with the existing Core nullable warning in `CrossFirebase.cs`.
