### PR TITLE
Cover iOS Firestore list null entries

### DIFF
--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -1585,6 +1585,27 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
             Assert.Equal(2L, Convert.ToInt64(result.Nested["outer"]["count"]));
         }
 
+        [Fact]
+        public async Task reads_null_entries_inside_firestore_lists()
+        {
+            if(!OperatingSystem.IsIOS()) {
+                return;
+            }
+
+            var sut = CrossFirebaseFirestore.Current;
+            var document = GetTestingDocument(sut, "list-null-values");
+            await document.SetDataAsync(new ListNullDocument(
+                values: new object[] { "first", null, "third" },
+                nullableNumbers: new long?[] { 1L, null, 3L }));
+
+            var snapshot = await document.GetDocumentSnapshotAsync<ListNullDocument>();
+
+            Assert.Equal("first", snapshot.Data.Values[0]);
+            Assert.Null(snapshot.Data.Values[1]);
+            Assert.Equal("third", snapshot.Data.Values[2]);
+            Assert.Equal(new long?[] { 1L, null, 3L }, snapshot.Data.NullableNumbers);
+        }
+
         public async Task DisposeAsync()
         {
             TestLog.Write($"[FIRESTORE CLEANUP START] {_testingCollectionPath}");
@@ -1614,6 +1635,27 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         private ICollectionReference GetTestingCollection(IFirebaseFirestore firestore)
         {
             return firestore.GetCollection(_testingCollectionPath);
+        }
+
+        [Preserve(AllMembers = true)]
+        private sealed class ListNullDocument : IFirestoreObject
+        {
+            public ListNullDocument()
+            {
+                // needed for firestore
+            }
+
+            public ListNullDocument(IList<object> values, IList<long?> nullableNumbers)
+            {
+                Values = values;
+                NullableNumbers = nullableNumbers;
+            }
+
+            [FirestoreProperty("values")]
+            public IList<object> Values { get; private set; }
+
+            [FirestoreProperty("nullable_numbers")]
+            public IList<long?> NullableNumbers { get; private set; }
         }
 
         [Preserve(AllMembers = true)]


### PR DESCRIPTION
## Summary

Adds focused acceptance coverage for #436: on iOS, Firestore arrays with null entries should read into `IFirestoreObject` list properties without failing.

This PR is test-only. The implementation fix is already present on `development` from the nullable Firestore work in #636; this keeps the issue-specific regression guard after rebasing over #648's raw dictionary coverage.

Fixes #436

## Validation

- `git diff --check origin/development...HEAD`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Release -f net9.0-android --no-restore`

Android Firestore build passed with the existing Core nullable warning in `src/Core/Platforms/Android/CrossFirebase.cs`.
