### PR TITLE
Fix Firestore double increment sentinel

### DIFF
--- a/src/Firestore/Shared/FieldValue.cs
+++ b/src/Firestore/Shared/FieldValue.cs
@@ -39,7 +39,7 @@ public sealed class FieldValue
     /// </summary>
     /// <param name="incrementValue">The value to increment.</param>
     public static FieldValue DoubleIncrement(double incrementValue) =>
-        new FieldValue(FieldValueType.IntegerIncrement, incrementValue);
+        new FieldValue(FieldValueType.DoubleIncrement, incrementValue);
 
     /// <summary>
     /// Returns a sentinel for use with <c>Update()</c> to mark a field for deletion.

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -75,6 +75,20 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         }
 
         [Fact]
+        public async Task increments_double_field_values()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var pokemon = PokemonFactory.CreateBulbasur();
+            var document = GetTestingDocument(sut, "double-increment");
+
+            await document.SetDataAsync(pokemon);
+            await document.UpdateDataAsync(("weight_in_kg", FieldValue.DoubleIncrement(0.25)));
+
+            var snapshot = await document.GetDocumentSnapshotAsync<Pokemon>();
+            Assert.Equal(pokemon.WeightInKg + 0.25, snapshot.Data.WeightInKg, 6);
+        }
+
+        [Fact]
         public async Task runs_transaction()
         {
             var sut = CrossFirebaseFirestore.Current;


### PR DESCRIPTION
## Summary

Fixes #624 by tagging `FieldValue.DoubleIncrement(double)` with `FieldValueType.DoubleIncrement` instead of `IntegerIncrement`.

## Root cause

The shared `DoubleIncrement` factory created a `FieldValue` with the integer sentinel type. Both platform converters then routed fractional increments through their integer increment paths.

## Validation

- `git diff --check origin/development`
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj -c Release -f net9.0 --no-restore`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Release -f net9.0-android --no-restore`