### PR TITLE
Fix Firestore nested NSDictionary conversion

### DIFF
--- a/src/Firestore/Platforms/iOS/Extensions/DictionaryExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/DictionaryExtensions.cs
@@ -18,7 +18,12 @@ public static class DictionaryExtensions
     )
     {
         if(dictionary.Count > 0) {
-            var nsDictionary = new NSMutableDictionary<NSString, NSObject>();
+            if(dictionary is NSDictionary nsDictionary) {
+                // NSDictionary implements IDictionary, but doesn't enumerate as DictionaryEntries, so we have to treat it special.
+                return nsDictionary.ToNSStringDictionary();
+            }
+
+            var nsMutableDictionary = new NSMutableDictionary<NSString, NSObject>();
 
             foreach(DictionaryEntry entry in dictionary) {
                 PutIntoNSDictionary(
@@ -26,17 +31,33 @@ public static class DictionaryExtensions
                         entry.Key.ToString() ?? throw new ArgumentException("Dictionary contains a null key."),
                         entry.Value
                     ),
-                    ref nsDictionary
+                    ref nsMutableDictionary
                 );
             }
             return NSDictionary<NSString, NSObject>.FromObjectsAndKeys(
-                nsDictionary.Values.ToArray(),
-                nsDictionary.Keys.ToArray(),
-                (nint) nsDictionary.Count
+                nsMutableDictionary.Values.ToArray(),
+                nsMutableDictionary.Keys.ToArray(),
+                (nint) nsMutableDictionary.Count
             );
         } else {
             return new NSDictionary<NSString, NSObject>();
         }
+    }
+
+    private static NSDictionary<NSString, NSObject> ToNSStringDictionary(this NSDictionary dictionary)
+    {
+        var mutableDictionary = new NSMutableDictionary<NSString, NSObject>();
+        foreach(var key in dictionary.Keys) {
+            var value = dictionary.ObjectForKey(key);
+            mutableDictionary.Add(
+                (NSString) (key.ToString() ?? throw new ArgumentException("Dictionary contains a null key.")),
+                value ?? throw new ArgumentException("Dictionary contains a null value.")
+            );
+        }
+        return NSDictionary<NSString, NSObject>.FromObjectsAndKeys(
+            mutableDictionary.Values.ToArray(),
+            mutableDictionary.Keys.ToArray(),
+            (nint) mutableDictionary.Count);
     }
 
     private static void PutIntoNSDictionary(

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -368,6 +368,55 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         }
 
         [Fact]
+        public async Task writes_nested_dictionary_maps_on_ios()
+        {
+            if(!OperatingSystem.IsIOS()) {
+                return;
+            }
+
+            var sut = CrossFirebaseFirestore.Current;
+            var nestedDictionary = new Dictionary<string, Dictionary<string, int>> {
+                {
+                    "first", new Dictionary<string, int> {
+                        { "wins", 3 },
+                        { "losses", 1 }
+                    }
+                },
+                {
+                    "second", new Dictionary<string, int> {
+                        { "wins", 5 },
+                        { "losses", 2 }
+                    }
+                }
+            };
+
+            var updateDocument = GetTestingDocument(sut, "nested-dictionary-update");
+            await updateDocument.SetDataAsync(new Dictionary<object, object> { { "seeded", true } });
+            await updateDocument.UpdateDataAsync(new Dictionary<object, object> {
+                { "foo", nestedDictionary }
+            });
+
+            var updateSnapshot = await updateDocument.GetDocumentSnapshotAsync<NestedDictionaryDocument>();
+            Assert.Equal(3, updateSnapshot.Data.Foo["first"]["wins"]);
+            Assert.Equal(1, updateSnapshot.Data.Foo["first"]["losses"]);
+            Assert.Equal(5, updateSnapshot.Data.Foo["second"]["wins"]);
+            Assert.Equal(2, updateSnapshot.Data.Foo["second"]["losses"]);
+
+            var parentDocument = GetTestingDocument(sut, "nested-dictionary-parent");
+            await parentDocument.SetDataAsync(
+                new NestedDictionaryParentDocument(
+                    new NestedDictionaryDocument(nestedDictionary)
+                )
+            );
+
+            var parentSnapshot = await parentDocument.GetDocumentSnapshotAsync<NestedDictionaryParentDocument>();
+            Assert.Equal(3, parentSnapshot.Data.Child.Foo["first"]["wins"]);
+            Assert.Equal(1, parentSnapshot.Data.Child.Foo["first"]["losses"]);
+            Assert.Equal(5, parentSnapshot.Data.Child.Foo["second"]["wins"]);
+            Assert.Equal(2, parentSnapshot.Data.Child.Foo["second"]["losses"]);
+        }
+
+        [Fact]
         public async Task gets_real_time_updates_on_multiple_documents()
         {
             var sut = CrossFirebaseFirestore.Current;

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/NestedDictionaryDocument.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/NestedDictionaryDocument.cs
@@ -1,0 +1,21 @@
+using Plugin.Firebase.Firestore;
+
+namespace Plugin.Firebase.IntegrationTests.Firestore
+{
+    public sealed class NestedDictionaryDocument : IFirestoreObject
+    {
+        [Preserve]
+        public NestedDictionaryDocument()
+        {
+            // needed for firestore
+        }
+
+        public NestedDictionaryDocument(Dictionary<string, Dictionary<string, int>> foo)
+        {
+            Foo = foo;
+        }
+
+        [FirestoreProperty("foo")]
+        public Dictionary<string, Dictionary<string, int>> Foo { get; private set; }
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/NestedDictionaryParentDocument.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/NestedDictionaryParentDocument.cs
@@ -1,0 +1,21 @@
+using Plugin.Firebase.Firestore;
+
+namespace Plugin.Firebase.IntegrationTests.Firestore
+{
+    public sealed class NestedDictionaryParentDocument : IFirestoreObject
+    {
+        [Preserve]
+        public NestedDictionaryParentDocument()
+        {
+            // needed for firestore
+        }
+
+        public NestedDictionaryParentDocument(NestedDictionaryDocument child)
+        {
+            Child = child;
+        }
+
+        [FirestoreProperty("child")]
+        public NestedDictionaryDocument Child { get; private set; }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Firestore iOS conversion when native snapshot data contains nested `NSDictionary` values. The change refactors `DictionaryExtensions` so nested native maps are converted through the shared dictionary conversion path, then adds iOS integration coverage for nested dictionary documents.

Fixes #526

## Validation

- `git diff --check origin/development`
- `dotnet format Plugin.Firebase.sln --verify-no-changes --no-restore --include src/Firestore/Platforms/iOS/Extensions/DictionaryExtensions.cs tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs tests/Plugin.Firebase.IntegrationTests/Firestore/NestedDictionaryDocument.cs tests/Plugin.Firebase.IntegrationTests/Firestore/NestedDictionaryParentDocument.cs`
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj -c Release -f net9.0 --no-restore`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Release -f net9.0-android --no-restore`

Android Firestore build still reports the existing nullable warning in `src/Core/Platforms/Android/CrossFirebase.cs`.