### PR TITLE
[codex] Fix auth token nested claims

### DIFF
--- a/src/Auth/Platforms/Android/AuthTokenResultWrapper.cs
+++ b/src/Auth/Platforms/Android/AuthTokenResultWrapper.cs
@@ -14,7 +14,7 @@ public sealed class AuthTokenResultWrapper : IAuthTokenResult
 
     public T GetClaim<T>(string key)
     {
-        return (T) _wrapped.Claims[key].ToObject(typeof(T));
+        return (T) _wrapped.Claims[key].ToObject(typeof(T))!;
     }
 
     public DateTimeOffset AuthDate => DateTimeOffset.FromUnixTimeSeconds(_wrapped.AuthTimestamp);

--- a/src/Auth/Platforms/Android/Extensions/DictionaryExtensions.cs
+++ b/src/Auth/Platforms/Android/Extensions/DictionaryExtensions.cs
@@ -1,3 +1,7 @@
+using System.Collections;
+using AndroidX.Collection;
+using Java.Util;
+
 namespace Plugin.Firebase.Auth.Platforms.Android.Extensions;
 
 public static class DictionaryExtensions
@@ -6,8 +10,176 @@ public static class DictionaryExtensions
     {
         var dict = new Dictionary<string, object>();
         foreach(var (key, value) in @this) {
-            dict[key] = value.ToObject();
+            dict[key] = ConvertToObject(typeof(object), value)!;
         }
         return dict;
+    }
+
+    internal static object ToDictionaryObject(this IDictionary @this, Type? targetType)
+    {
+        if(targetType == null || targetType == typeof(object)) {
+            return @this.ToDictionary();
+        }
+
+        if(targetType.IsGenericType && (
+            targetType.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
+            targetType.GetGenericTypeDefinition() == typeof(Dictionary<,>)
+        )) {
+            var types = targetType.GenericTypeArguments;
+            return @this.ToDictionary(types[0], types[1]);
+        }
+
+        return @this.ToDictionary();
+    }
+
+    internal static object ToDictionaryObject(this IMap @this, Type? targetType)
+    {
+        if(targetType == null || targetType == typeof(object)) {
+            return @this.ToDictionary();
+        }
+
+        if(targetType.IsGenericType && (
+            targetType.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
+            targetType.GetGenericTypeDefinition() == typeof(Dictionary<,>)
+        )) {
+            var types = targetType.GenericTypeArguments;
+            return @this.ToDictionary(types[0], types[1]);
+        }
+
+        return @this.ToDictionary();
+    }
+
+    internal static object ToDictionaryObject(this ArrayMap @this, Type? targetType)
+    {
+        if(targetType == null || targetType == typeof(object)) {
+            return @this.ToDictionary();
+        }
+
+        if(targetType.IsGenericType && (
+            targetType.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
+            targetType.GetGenericTypeDefinition() == typeof(Dictionary<,>)
+        )) {
+            var types = targetType.GenericTypeArguments;
+            return @this.ToDictionary(types[0], types[1]);
+        }
+
+        return @this.ToDictionary();
+    }
+
+    public static IDictionary ToDictionary(this IDictionary @this, Type keyType, Type valueType)
+    {
+        var dict = (IDictionary)
+            Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(keyType, valueType))!;
+        foreach(DictionaryEntry pair in @this) {
+            dict![ConvertToObject(keyType, pair.Key)!] = ConvertToObject(valueType, pair.Value);
+        }
+        return dict!;
+    }
+
+    public static IDictionary<string, object> ToDictionary(this IDictionary @this)
+    {
+        var dict = new Dictionary<string, object>();
+        foreach(DictionaryEntry pair in @this) {
+            var key = pair.Key?.ToString();
+            if(key is null) {
+                throw new ArgumentException("Dictionary contains a null key.");
+            }
+
+            dict[key] = ConvertToObject(typeof(object), pair.Value)!;
+        }
+        return dict;
+    }
+
+    public static IDictionary ToDictionary(this IMap @this, Type keyType, Type valueType)
+    {
+        var dict = (IDictionary)
+            Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(keyType, valueType))!;
+        foreach(var key in @this.KeySet()!) {
+            var javaKey = ConvertToJavaMapKey(key);
+            dict![ConvertToObject(keyType, key)!] = ConvertToObject(
+                valueType,
+                @this.Get(javaKey)
+            );
+        }
+        return dict!;
+    }
+
+    public static IDictionary<string, object> ToDictionary(this IMap @this)
+    {
+        var dict = new Dictionary<string, object>();
+        foreach(var key in @this.KeySet()!) {
+            var javaKey = ConvertToJavaMapKey(key);
+            var keyString = key?.ToString();
+            if(keyString is null) {
+                throw new ArgumentException("Dictionary contains a null key.");
+            }
+
+            dict[keyString] = ConvertToObject(typeof(object), @this.Get(javaKey))!;
+        }
+        return dict;
+    }
+
+    public static IDictionary ToDictionary(this ArrayMap @this, Type keyType, Type valueType)
+    {
+        var dict = (IDictionary)
+            Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(keyType, valueType))!;
+        foreach(var key in @this.KeySet()!) {
+            var javaKey = ConvertToJavaMapKey(key);
+            dict![ConvertToObject(keyType, key)!] = ConvertToObject(
+                valueType,
+                @this.Get(javaKey)
+            );
+        }
+        return dict!;
+    }
+
+    public static IDictionary<string, object> ToDictionary(this ArrayMap @this)
+    {
+        var dict = new Dictionary<string, object>();
+        foreach(var key in @this.KeySet()!) {
+            var javaKey = ConvertToJavaMapKey(key);
+            var keyString = key?.ToString();
+            if(keyString is null) {
+                throw new ArgumentException("Dictionary contains a null key.");
+            }
+
+            dict[keyString] = ConvertToObject(typeof(object), @this.Get(javaKey))!;
+        }
+        return dict;
+    }
+
+    private static object? ConvertToObject(Type targetType, object? value)
+    {
+        if(value is null) {
+            return null;
+        }
+
+        if(targetType == typeof(string)) {
+            return value is Java.Lang.ICharSequence charSequence
+                ? charSequence.ToString()
+                : value.ToString();
+        }
+
+        if(value is Java.Lang.Object javaValue) {
+            return javaValue.ToObject(targetType);
+        }
+
+        return targetType == typeof(object)
+            ? value
+            : Convert.ChangeType(value, Nullable.GetUnderlyingType(targetType) ?? targetType);
+    }
+
+    private static Java.Lang.Object ConvertToJavaMapKey(object? key)
+    {
+        if(key is null) {
+            throw new ArgumentException("Dictionary contains a null key.");
+        }
+
+        if(key is Java.Lang.Object javaKey) {
+            return javaKey;
+        }
+
+        return key.ToJavaObject()
+            ?? throw new ArgumentException("Dictionary contains a null key.");
     }
 }

--- a/src/Auth/Platforms/Android/Extensions/JavaObjectExtensions.cs
+++ b/src/Auth/Platforms/Android/Extensions/JavaObjectExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Android.Runtime;
 using AndroidX.Collection;
 using Java.Util;
@@ -7,7 +8,7 @@ namespace Plugin.Firebase.Auth.Platforms.Android.Extensions;
 
 public static class JavaObjectExtensions
 {
-    public static object ToObject(this Java.Lang.Object @this, Type? targetType = null)
+    public static object? ToObject(this Java.Lang.Object @this, Type? targetType = null)
     {
         switch(@this) {
             case Java.Lang.ICharSequence x:
@@ -25,9 +26,17 @@ public static class JavaObjectExtensions
             case Date x:
                 return x.ToDateTimeOffset();
             case ArrayMap x:
-                return x.ToDictionary();
+                return x.ToDictionaryObject(targetType);
+            case IMap x:
+                return x.ToDictionaryObject(targetType);
+            case IDictionary x:
+                return x.ToDictionaryObject(targetType);
+            case Java.Util.IList x:
+                return x.ToList(GetGenericListType(targetType));
             case JavaList x:
-                return x.ToList(targetType?.GenericTypeArguments[0]);
+                return x.ToList(GetGenericListType(targetType));
+            case Java.Lang.Object x when x.GetType() == typeof(Java.Lang.Object):
+                return null;
             default:
                 throw new ArgumentException(
                     $"Could not convert Java.Lang.Object of type {@this.GetType()} to object"
@@ -85,23 +94,8 @@ public static class JavaObjectExtensions
         }
     }
 
-    public static IDictionary<string, object> ToDictionary(this ArrayMap @this)
+    private static Type GetGenericListType(Type? targetType)
     {
-        var dict = new Dictionary<string, object>();
-        var keys = @this.KeySet()!;
-        foreach(var key in keys) {
-            var keyString = key.ToString();
-            if(keyString is null) {
-                throw new ArgumentException("Dictionary contains a null key.");
-            }
-
-            var value = @this.Get(keyString);
-            if(value is null) {
-                throw new ArgumentException("Dictionary contains a null value.");
-            }
-
-            dict[keyString] = value.ToObject();
-        }
-        return dict;
+        return targetType?.GenericTypeArguments?.FirstOrDefault() ?? typeof(object);
     }
 }

--- a/src/Auth/Platforms/Android/Extensions/ListExtensions.cs
+++ b/src/Auth/Platforms/Android/Extensions/ListExtensions.cs
@@ -5,21 +5,22 @@ namespace Plugin.Firebase.Auth.Platforms.Android.Extensions;
 
 public static class ListExtensions
 {
+    public static IList ToList(this Java.Util.IList @this, Type? targetType = null)
+    {
+        var list = CreateList(targetType);
+        for(var i = 0; i < @this.Size(); i++) {
+            AddConvertedValue(list, @this.Get(i), targetType);
+        }
+        return list;
+    }
+
     public static IList ToList(this JavaList @this, Type? targetType = null)
     {
-        var list =
-            targetType == null
-                ? new List<object>()
-                : (IList) Activator.CreateInstance(typeof(List<>).MakeGenericType(targetType))!;
+        var list = CreateList(targetType);
         for(var i = 0; i < @this.Size(); i++) {
-            var value = @this[i];
-            if(value is Java.Lang.Object javaValue) {
-                list!.Add(javaValue.ToObject(targetType));
-            } else {
-                list!.Add(value);
-            }
+            AddConvertedValue(list, @this[i], targetType);
         }
-        return list!;
+        return list;
     }
 
     public static JavaList ToJavaList(this IEnumerable @this)
@@ -29,5 +30,21 @@ public static class ListExtensions
             list.Add(item.ToJavaObject());
         }
         return list;
+    }
+
+    private static IList CreateList(Type? targetType)
+    {
+        return targetType == null
+            ? new List<object?>()
+            : (IList) Activator.CreateInstance(typeof(List<>).MakeGenericType(targetType))!;
+    }
+
+    private static void AddConvertedValue(IList list, object? value, Type? targetType)
+    {
+        if(value is Java.Lang.Object javaValue) {
+            list.Add(javaValue.ToObject(targetType));
+        } else {
+            list.Add(value);
+        }
     }
 }

--- a/src/Auth/Platforms/iOS/Extensions/DictionaryExtensions.cs
+++ b/src/Auth/Platforms/iOS/Extensions/DictionaryExtensions.cs
@@ -24,6 +24,23 @@ public static class DictionaryExtensions
         return dict!;
     }
 
+    internal static object ToDictionaryObject(this NSDictionary @this, Type? targetType)
+    {
+        if(targetType == null || targetType == typeof(object)) {
+            return @this.ToDictionary();
+        }
+
+        if(targetType.IsGenericType && (
+            targetType.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
+            targetType.GetGenericTypeDefinition() == typeof(Dictionary<,>)
+        )) {
+            var types = targetType.GenericTypeArguments;
+            return @this.ToDictionary(types[0], types[1]);
+        }
+
+        return @this.ToDictionary();
+    }
+
     /// <summary>
     /// Converts a typed NSDictionary to a .NET dictionary with string keys and object values.
     /// </summary>

--- a/src/Auth/Platforms/iOS/Extensions/NSObjectExtensions.cs
+++ b/src/Auth/Platforms/iOS/Extensions/NSObjectExtensions.cs
@@ -23,13 +23,8 @@ public static class NSObjectExtensions
                 return x.ToString();
             case NSDate x:
                 return x.ToDateTimeOffset();
-            case NSDictionary x when targetType?.GenericTypeArguments?.Length == 2:
-                return x.ToDictionary(
-                    targetType.GenericTypeArguments[0],
-                    targetType.GenericTypeArguments[1]
-                );
             case NSDictionary x:
-                return x.ToDictionary();
+                return x.ToDictionaryObject(targetType);
             case NSArray x:
                 return x.ToList(GetGenericListType(targetType)!);
             case NSNull:
@@ -49,11 +44,16 @@ public static class NSObjectExtensions
     /// <returns>The converted .NET numeric value, or null if the type is not supported.</returns>
     public static object? ToObject(this NSNumber @this, Type? targetType = null)
     {
-        if(targetType == null) {
-            return @this.Int32Value;
+        if(targetType == null || targetType == typeof(object)) {
+            return @this.ToUntypedObject();
         }
 
-        switch(Type.GetTypeCode(targetType)) {
+        var conversionType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        if(conversionType.IsEnum) {
+            return Enum.ToObject(conversionType, @this.Int64Value);
+        }
+
+        switch(Type.GetTypeCode(conversionType)) {
             case TypeCode.Boolean:
                 return @this.BoolValue;
             case TypeCode.Char:
@@ -83,7 +83,38 @@ public static class NSObjectExtensions
         }
     }
 
-    private static Type? GetGenericListType(Type? targetType)
+    private static object ToUntypedObject(this NSNumber @this)
+    {
+        switch(@this.ObjCType) {
+            case "B":
+            case "c":
+                return @this.BoolValue;
+            case "C":
+                return @this.ByteValue;
+            case "s":
+                return @this.Int16Value;
+            case "S":
+                return @this.UInt16Value;
+            case "i":
+                return @this.Int32Value;
+            case "I":
+                return @this.UInt32Value;
+            case "q":
+            case "l":
+                return @this.Int64Value;
+            case "Q":
+            case "L":
+                return @this.UInt64Value;
+            case "f":
+                return @this.FloatValue;
+            case "d":
+                return @this.DoubleValue;
+            default:
+                return @this.Int64Value;
+        }
+    }
+
+    private static Type GetGenericListType(Type? targetType)
     {
         return targetType?.GenericTypeArguments?.FirstOrDefault() ?? typeof(object);
     }

--- a/src/Auth/Shared/IAuthTokenResult.cs
+++ b/src/Auth/Shared/IAuthTokenResult.cs
@@ -6,7 +6,8 @@ namespace Plugin.Firebase.Auth;
 public interface IAuthTokenResult
 {
     /// <summary>
-    /// Retrieves the claim casted to the generic type param.
+    /// Retrieves the claim casted to the generic type parameter. Nested JSON objects are returned as dictionaries, and
+    /// nested JSON arrays are returned as lists.
     /// </summary>
     /// <param name="key">Key of the claim</param>
     /// <typeparam name="T">Type of the claim</typeparam>
@@ -20,7 +21,8 @@ public interface IAuthTokenResult
 
     /// <summary>
     /// Stores the entire payload of claims found on the ID token. This includes the standard reserved claims as well as custom claims
-    /// set by the developer via the Admin SDK.
+    /// set by the developer via the Admin SDK. Nested JSON objects are represented as dictionaries, and nested JSON arrays are represented
+    /// as lists.
     /// </summary>
     IDictionary<string, object> Claims { get; }
 

--- a/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
@@ -300,6 +300,43 @@ namespace Plugin.Firebase.IntegrationTests.Auth
             await sut.SignOutAsync(); // sign out so the user won't get deleted
 
             Assert.True(idTokenResult.GetClaim<bool>("is_awesome"));
+            var nestedObject = Assert.IsAssignableFrom<IDictionary<string, object>>(
+                idTokenResult.Claims["nested_object"]
+            );
+            NestedClaimAssertions.AssertNestedCustomClaim(nestedObject);
+
+            var typedNestedObject = idTokenResult.GetClaim<IDictionary<string, object>>(
+                "nested_object"
+            );
+            NestedClaimAssertions.AssertNestedCustomClaim(typedNestedObject);
+
+            var concreteNestedObject = idTokenResult.GetClaim<Dictionary<string, object>>(
+                "nested_object"
+            );
+            NestedClaimAssertions.AssertNestedCustomClaim(concreteNestedObject);
+
+            var objectNestedObject = Assert.IsAssignableFrom<IDictionary<string, object>>(
+                idTokenResult.GetClaim<object>("nested_object")
+            );
+            NestedClaimAssertions.AssertNestedCustomClaim(objectNestedObject);
+
+            var nestedArray = Assert.IsAssignableFrom<IList<object>>(
+                idTokenResult.Claims["nested_array"]
+            );
+            NestedClaimAssertions.AssertNestedCustomArray(nestedArray);
+
+            var typedNestedArray = idTokenResult.GetClaim<IList<object>>("nested_array");
+            NestedClaimAssertions.AssertNestedCustomArray(typedNestedArray);
+
+            var concreteNestedArray = idTokenResult.GetClaim<List<object>>("nested_array");
+            NestedClaimAssertions.AssertNestedCustomArray(concreteNestedArray);
+
+            var objectNestedArray = Assert.IsAssignableFrom<IList<object>>(
+                idTokenResult.GetClaim<object>("nested_array")
+            );
+            NestedClaimAssertions.AssertNestedCustomArray(objectNestedArray);
+
+            Assert.True(Assert.IsType<bool>(idTokenResult.GetClaim<object>("is_awesome")));
         }
 
         [Fact]

--- a/tests/Plugin.Firebase.IntegrationTests/Auth/AuthTokenClaimConversionFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Auth/AuthTokenClaimConversionFixture.cs
@@ -1,0 +1,261 @@
+#if ANDROID
+using Java.Util;
+using Plugin.Firebase.Auth.Platforms.Android.Extensions;
+#elif IOS
+using Foundation;
+using Plugin.Firebase.Auth.Platforms.iOS.Extensions;
+#endif
+
+namespace Plugin.Firebase.IntegrationTests.Auth
+{
+    [Collection("Sequential")]
+    [TestLogging]
+    [Microsoft.Maui.Controls.Internals.Preserve(AllMembers = true)]
+    public sealed class AuthTokenClaimConversionFixture
+    {
+#if ANDROID
+        [Fact]
+        public void converts_android_hashmap_claim_objects_recursively()
+        {
+            var nestedObject = CreateAndroidNestedObject();
+
+            var converted = Assert.IsAssignableFrom<IDictionary<string, object>>(
+                nestedObject.ToObject()
+            );
+            NestedClaimAssertions.AssertNestedCustomClaim(converted);
+
+            var typedInterface = Assert.IsAssignableFrom<IDictionary<string, object>>(
+                nestedObject.ToObject(typeof(IDictionary<string, object>))
+            );
+            NestedClaimAssertions.AssertNestedCustomClaim(typedInterface);
+
+            var typedConcrete = Assert.IsType<Dictionary<string, object>>(
+                nestedObject.ToObject(typeof(Dictionary<string, object>))
+            );
+            NestedClaimAssertions.AssertNestedCustomClaim(typedConcrete);
+
+            var objectConverted = Assert.IsAssignableFrom<IDictionary<string, object>>(
+                nestedObject.ToObject(typeof(object))
+            );
+            NestedClaimAssertions.AssertNestedCustomClaim(objectConverted);
+        }
+
+        [Fact]
+        public void converts_android_arraylist_claim_arrays_recursively()
+        {
+            var nestedArray = CreateAndroidNestedArray();
+
+            var converted = Assert.IsAssignableFrom<IList<object>>(nestedArray.ToObject());
+            NestedClaimAssertions.AssertNestedCustomArray(converted);
+
+            var typedInterface = Assert.IsAssignableFrom<IList<object>>(
+                nestedArray.ToObject(typeof(IList<object>))
+            );
+            NestedClaimAssertions.AssertNestedCustomArray(typedInterface);
+
+            var typedConcrete = Assert.IsType<List<object>>(
+                nestedArray.ToObject(typeof(List<object>))
+            );
+            NestedClaimAssertions.AssertNestedCustomArray(typedConcrete);
+
+            var objectConverted = Assert.IsAssignableFrom<IList<object>>(
+                nestedArray.ToObject(typeof(object))
+            );
+            NestedClaimAssertions.AssertNestedCustomArray(objectConverted);
+        }
+
+        private static HashMap CreateAndroidNestedObject()
+        {
+            var nested = new HashMap();
+            nested.Put("enabled", true);
+            nested.Put("roles", CreateAndroidRoles());
+            nested.Put("metadata", CreateAndroidMetadata());
+            nested.Put("history", CreateAndroidHistory());
+            nested.Put("score", 7);
+            nested.Put("ratio", 1.5);
+            nested.Put("optional", null);
+            return nested;
+        }
+
+        private static ArrayList CreateAndroidNestedArray()
+        {
+            var first = new HashMap();
+            first.Put("name", "first");
+            var flags = new ArrayList();
+            flags.Add(true);
+            flags.Add(false);
+            first.Put("flags", flags);
+
+            var second = new HashMap();
+            second.Put("name", "second");
+            second.Put("metadata", CreateAndroidMetadata(includeVersion: false));
+
+            var nestedArray = new ArrayList();
+            nestedArray.Add(first);
+            nestedArray.Add(second);
+            return nestedArray;
+        }
+
+        private static ArrayList CreateAndroidRoles()
+        {
+            var roles = new ArrayList();
+            roles.Add("admin");
+            roles.Add("tester");
+            return roles;
+        }
+
+        private static HashMap CreateAndroidMetadata(bool includeVersion = true)
+        {
+            var metadata = new HashMap();
+            metadata.Put("source", "emulator");
+            if(includeVersion) {
+                metadata.Put("version", 2);
+            }
+            return metadata;
+        }
+
+        private static ArrayList CreateAndroidHistory()
+        {
+            var created = new HashMap();
+            created.Put("action", "created");
+            created.Put("count", 1);
+
+            var updated = new HashMap();
+            updated.Put("action", "updated");
+            updated.Put("count", 2);
+
+            var history = new ArrayList();
+            history.Add(created);
+            history.Add(updated);
+            return history;
+        }
+#endif
+
+#if IOS
+        [Fact]
+        public void converts_ios_dictionary_claim_objects_recursively()
+        {
+            var nestedObject = CreateIosNestedObject();
+
+            var converted = Assert.IsAssignableFrom<IDictionary<string, object>>(
+                nestedObject.ToObject()
+            );
+            NestedClaimAssertions.AssertNestedCustomClaim(converted);
+
+            var typedInterface = Assert.IsAssignableFrom<IDictionary<string, object>>(
+                nestedObject.ToObject(typeof(IDictionary<string, object>))
+            );
+            NestedClaimAssertions.AssertNestedCustomClaim(typedInterface);
+
+            var typedConcrete = Assert.IsType<Dictionary<string, object>>(
+                nestedObject.ToObject(typeof(Dictionary<string, object>))
+            );
+            NestedClaimAssertions.AssertNestedCustomClaim(typedConcrete);
+
+            var objectConverted = Assert.IsAssignableFrom<IDictionary<string, object>>(
+                nestedObject.ToObject(typeof(object))
+            );
+            NestedClaimAssertions.AssertNestedCustomClaim(objectConverted);
+        }
+
+        [Fact]
+        public void converts_ios_array_claim_arrays_recursively()
+        {
+            var nestedArray = CreateIosNestedArray();
+
+            var converted = Assert.IsAssignableFrom<IList<object>>(nestedArray.ToObject());
+            NestedClaimAssertions.AssertNestedCustomArray(converted);
+
+            var typedInterface = Assert.IsAssignableFrom<IList<object>>(
+                nestedArray.ToObject(typeof(IList<object>))
+            );
+            NestedClaimAssertions.AssertNestedCustomArray(typedInterface);
+
+            var typedConcrete = Assert.IsType<List<object>>(
+                nestedArray.ToObject(typeof(List<object>))
+            );
+            NestedClaimAssertions.AssertNestedCustomArray(typedConcrete);
+
+            var objectConverted = Assert.IsAssignableFrom<IList<object>>(
+                nestedArray.ToObject(typeof(object))
+            );
+            NestedClaimAssertions.AssertNestedCustomArray(objectConverted);
+        }
+
+        private static NSDictionary CreateIosNestedObject()
+        {
+            return NSDictionary.FromObjectsAndKeys(
+                new NSObject[] {
+                    NSNumber.FromBoolean(true),
+                    CreateIosRoles(),
+                    CreateIosMetadata(),
+                    CreateIosHistory(),
+                    NSNumber.FromInt32(7),
+                    NSNumber.FromDouble(1.5),
+                    NSNull.Null,
+                },
+                new NSObject[] {
+                    new NSString("enabled"),
+                    new NSString("roles"),
+                    new NSString("metadata"),
+                    new NSString("history"),
+                    new NSString("score"),
+                    new NSString("ratio"),
+                    new NSString("optional"),
+                }
+            );
+        }
+
+        private static NSArray CreateIosNestedArray()
+        {
+            var first = NSDictionary.FromObjectsAndKeys(
+                new NSObject[] {
+                    new NSString("first"),
+                    NSArray.FromNSObjects(NSNumber.FromBoolean(true), NSNumber.FromBoolean(false)),
+                },
+                new NSObject[] { new NSString("name"), new NSString("flags") }
+            );
+            var second = NSDictionary.FromObjectsAndKeys(
+                new NSObject[] { new NSString("second"), CreateIosMetadata(includeVersion: false) },
+                new NSObject[] { new NSString("name"), new NSString("metadata") }
+            );
+
+            return NSArray.FromNSObjects(first, second);
+        }
+
+        private static NSArray CreateIosRoles()
+        {
+            return NSArray.FromNSObjects(new NSString("admin"), new NSString("tester"));
+        }
+
+        private static NSDictionary CreateIosMetadata(bool includeVersion = true)
+        {
+            if(!includeVersion) {
+                return NSDictionary.FromObjectsAndKeys(
+                    new NSObject[] { new NSString("emulator") },
+                    new NSObject[] { new NSString("source") }
+                );
+            }
+
+            return NSDictionary.FromObjectsAndKeys(
+                new NSObject[] { new NSString("emulator"), NSNumber.FromInt32(2) },
+                new NSObject[] { new NSString("source"), new NSString("version") }
+            );
+        }
+
+        private static NSArray CreateIosHistory()
+        {
+            var created = NSDictionary.FromObjectsAndKeys(
+                new NSObject[] { new NSString("created"), NSNumber.FromInt32(1) },
+                new NSObject[] { new NSString("action"), new NSString("count") }
+            );
+            var updated = NSDictionary.FromObjectsAndKeys(
+                new NSObject[] { new NSString("updated"), NSNumber.FromInt32(2) },
+                new NSObject[] { new NSString("action"), new NSString("count") }
+            );
+
+            return NSArray.FromNSObjects(created, updated);
+        }
+#endif
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/Auth/NestedClaimAssertions.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Auth/NestedClaimAssertions.cs
@@ -1,0 +1,60 @@
+namespace Plugin.Firebase.IntegrationTests.Auth
+{
+    internal static class NestedClaimAssertions
+    {
+        public static void AssertNestedCustomClaim(IDictionary<string, object> nestedObject)
+        {
+            Assert.True(Convert.ToBoolean(nestedObject["enabled"]));
+
+            var roles = Assert.IsAssignableFrom<IList<object>>(nestedObject["roles"]);
+            Assert.Equal(new[] { "admin", "tester" }, roles.Select(x => Assert.IsType<string>(x)));
+
+            var metadata = Assert.IsAssignableFrom<IDictionary<string, object>>(
+                nestedObject["metadata"]
+            );
+            Assert.Equal("emulator", Assert.IsType<string>(metadata["source"]));
+            Assert.Equal(2L, Convert.ToInt64(metadata["version"]));
+
+            var history = Assert.IsAssignableFrom<IList<object>>(nestedObject["history"]);
+            Assert.Collection(
+                history,
+                item => AssertHistoryItem(item, "created", 1),
+                item => AssertHistoryItem(item, "updated", 2)
+            );
+
+            Assert.Equal(7L, Convert.ToInt64(nestedObject["score"]));
+            Assert.Equal(1.5, Convert.ToDouble(nestedObject["ratio"]), precision: 3);
+            Assert.Null(nestedObject["optional"]);
+        }
+
+        public static void AssertNestedCustomArray(IList<object> nestedArray)
+        {
+            Assert.Collection(
+                nestedArray,
+                item => {
+                    var dict = Assert.IsAssignableFrom<IDictionary<string, object>>(item);
+                    Assert.Equal("first", Assert.IsType<string>(dict["name"]));
+
+                    var flags = Assert.IsAssignableFrom<IList<object>>(dict["flags"]);
+                    Assert.Equal(new[] { true, false }, flags.Select(Convert.ToBoolean));
+                },
+                item => {
+                    var dict = Assert.IsAssignableFrom<IDictionary<string, object>>(item);
+                    Assert.Equal("second", Assert.IsType<string>(dict["name"]));
+
+                    var metadata = Assert.IsAssignableFrom<IDictionary<string, object>>(
+                        dict["metadata"]
+                    );
+                    Assert.Equal("emulator", Assert.IsType<string>(metadata["source"]));
+                }
+            );
+        }
+
+        private static void AssertHistoryItem(object item, string action, int count)
+        {
+            var dict = Assert.IsAssignableFrom<IDictionary<string, object>>(item);
+            Assert.Equal(action, Assert.IsType<string>(dict["action"]));
+            Assert.Equal(count, Convert.ToInt32(dict["count"]));
+        }
+    }
+}

--- a/tests/cloud-functions/scripts/seed-auth-emulator.js
+++ b/tests/cloud-functions/scripts/seed-auth-emulator.js
@@ -47,7 +47,28 @@ async function main() {
   });
   await admin
     .auth()
-    .setCustomUserClaims(customClaimsUser.uid, { is_awesome: true });
+    .setCustomUserClaims(customClaimsUser.uid, {
+      is_awesome: true,
+      nested_object: {
+        enabled: true,
+        roles: ["admin", "tester"],
+        metadata: {
+          source: "emulator",
+          version: 2,
+        },
+        history: [
+          { action: "created", count: 1 },
+          { action: "updated", count: 2 },
+        ],
+        score: 7,
+        ratio: 1.5,
+        optional: null,
+      },
+      nested_array: [
+        { name: "first", flags: [true, false] },
+        { name: "second", metadata: { source: "emulator" } },
+      ],
+    });
   console.log("[auth seed] recreated custom-claims@test.com");
 }
 


### PR DESCRIPTION
## Summary

Fixes #607 by making Auth token custom claim conversion recursively handle nested JSON objects and arrays on iOS and Android while keeping the public Auth token API unchanged.

## Changes

- Convert nested iOS `NSDictionary` / `NSArray` values into .NET dictionaries and lists.
- Convert nested Android Java maps and lists, including `HashMap` claim values, into .NET dictionaries and lists.
- Preserve `GetClaim<T>()` support for nested `IDictionary<string, object>`, `Dictionary<string, object>`, lists, primitives, and `object` claims.
- Document nested claim behavior on `IAuthTokenResult.Claims` and `GetClaim<T>()`.
- Expand emulator custom-claim seed data and integration assertions for nested objects, arrays, primitive values, and nulls.

## Validation

- `dotnet format Plugin.Firebase.sln --include ...`
- `git diff --check`
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj`
- `dotnet build src/Auth/Auth.csproj -c Release -f net9.0-android`
- `dotnet build src/Auth/Auth.csproj -c Release -f net9.0-ios`
- Android integration suite with Firebase emulators: 88 run, 72 passed, 16 skipped
- iOS simulator integration suite: 87 run, 71 passed, 16 skipped