### PR TITLE
[codex] Fix AppCheck nullability warnings

### DIFF
--- a/src/AppCheck/AppCheck.csproj
+++ b/src/AppCheck/AppCheck.csproj
@@ -4,6 +4,8 @@
         <TargetFrameworks>net9.0;net9.0-android;net9.0-ios</TargetFrameworks>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 

--- a/src/AppCheck/Platforms/Android/FirebaseAppCheckImplementation.cs
+++ b/src/AppCheck/Platforms/Android/FirebaseAppCheckImplementation.cs
@@ -10,7 +10,7 @@ public sealed class FirebaseAppCheckImplementation : IFirebaseAppCheck
 {
     private readonly object _syncRoot = new();
     private AppCheckOptions _options = AppCheckOptions.Disabled;
-    private IDisposable _afterInitializeRegistration;
+    private IDisposable? _afterInitializeRegistration;
 
     public void Configure(AppCheckOptions options)
     {
@@ -59,7 +59,7 @@ public sealed class FirebaseAppCheckImplementation : IFirebaseAppCheck
             $"Plugin.Firebase AppCheck: installing provider factory '{options.Provider}' (Android)."
         );
 
-        IAppCheckProviderFactory factory = null;
+        IAppCheckProviderFactory? factory = null;
         switch(options.Provider) {
             case AppCheckProviderType.Debug:
                 factory = (IAppCheckProviderFactory) DebugAppCheckProviderFactory.Instance;

--- a/src/AppCheck/Platforms/iOS/FirebaseAppCheckImplementation.cs
+++ b/src/AppCheck/Platforms/iOS/FirebaseAppCheckImplementation.cs
@@ -12,7 +12,7 @@ public sealed class FirebaseAppCheckImplementation : IFirebaseAppCheck
 {
     private readonly object _syncRoot = new();
     private AppCheckOptions _options = AppCheckOptions.Disabled;
-    private IDisposable _beforeConfigureRegistration;
+    private IDisposable? _beforeConfigureRegistration;
 
     /// <summary>
     /// Configures the Firebase AppCheck service with the specified options.
@@ -119,7 +119,7 @@ public sealed class FirebaseAppCheckImplementation : IFirebaseAppCheck
 
     private sealed class AppAttestProviderFactoryAdapter : NSObject, IAppCheckProviderFactory
     {
-        public NSObject CreateProviderWithApp(App app)
+        public NSObject? CreateProviderWithApp(App app)
         {
             if(!OperatingSystem.IsIOSVersionAtLeast(14)) {
                 return null;

--- a/src/AppCheck/Shared/CrossFirebaseAppCheck.cs
+++ b/src/AppCheck/Shared/CrossFirebaseAppCheck.cs
@@ -5,9 +5,9 @@ namespace Plugin.Firebase.AppCheck;
 /// </summary>
 public sealed class CrossFirebaseAppCheck
 {
-    private static Lazy<IFirebaseAppCheck> _implementation = new Lazy<IFirebaseAppCheck>(CreateInstance, LazyThreadSafetyMode.PublicationOnly);
+    private static Lazy<IFirebaseAppCheck?> _implementation = new Lazy<IFirebaseAppCheck?>(CreateInstance, LazyThreadSafetyMode.PublicationOnly);
 
-    private static IFirebaseAppCheck CreateInstance()
+    private static IFirebaseAppCheck? CreateInstance()
     {
 #if IOS || ANDROID
         return new FirebaseAppCheckImplementation();
@@ -64,8 +64,8 @@ public sealed class CrossFirebaseAppCheck
     public static void Dispose()
     {
         if(_implementation != null && _implementation.IsValueCreated) {
-            _implementation.Value.Dispose();
-            _implementation = new Lazy<IFirebaseAppCheck>(CreateInstance, LazyThreadSafetyMode.PublicationOnly);
+            _implementation.Value?.Dispose();
+            _implementation = new Lazy<IFirebaseAppCheck?>(CreateInstance, LazyThreadSafetyMode.PublicationOnly);
         }
     }
 }

--- a/src/Core/Platforms/Android/CrossFirebase.cs
+++ b/src/Core/Platforms/Android/CrossFirebase.cs
@@ -1,4 +1,5 @@
 using Firebase;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Plugin.Firebase.Core.Platforms.Android;
 
@@ -56,7 +57,8 @@ public static class CrossFirebase
     /// Safely checks whether a default FirebaseApp exists.
     /// FirebaseApp.Instance (getInstance()) throws IllegalStateException when no default app is configured.
     /// </summary>
-    public static bool TryGetDefaultApp(out FirebaseApp app)
+    /// <param name="app">The default Firebase app when this method returns true; otherwise null.</param>
+    public static bool TryGetDefaultApp([NotNullWhen(true)] out FirebaseApp? app)
     {
         try {
             app = FirebaseApp.Instance;


### PR DESCRIPTION
## Summary
- Enable nullable analysis and warnings-as-errors for Plugin.Firebase.AppCheck.
- Annotate AppCheck shared and platform implementation state to match nullable behavior.
- Align the iOS App Attest provider adapter with the native binding nullable return contract.
- Annotate the Android Core TryGetDefaultApp out parameter so clean AppCheck Android builds do not inherit a referenced-project nullable warning.

## Validation
- dotnet build src/AppCheck/AppCheck.csproj -c Release -f net9.0 --no-restore --no-incremental
- dotnet build src/AppCheck/AppCheck.csproj -c Release -f net9.0-android --no-restore --no-incremental
- dotnet build src/AppCheck/AppCheck.csproj -c Release -f net9.0-ios --no-restore --no-incremental