### PR TITLE
[codex] Fix RemoteConfig nullability warnings

### DIFF
--- a/src/Core/Platforms/Android/CrossFirebase.cs
+++ b/src/Core/Platforms/Android/CrossFirebase.cs
@@ -1,4 +1,5 @@
 using Firebase;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Plugin.Firebase.Core.Platforms.Android;
 
@@ -56,7 +57,8 @@ public static class CrossFirebase
     /// Safely checks whether a default FirebaseApp exists.
     /// FirebaseApp.Instance (getInstance()) throws IllegalStateException when no default app is configured.
     /// </summary>
-    public static bool TryGetDefaultApp(out FirebaseApp app)
+    /// <param name="app">The default Firebase app when this method returns true; otherwise null.</param>
+    public static bool TryGetDefaultApp([NotNullWhen(true)] out FirebaseApp? app)
     {
         try {
             app = FirebaseApp.Instance;

--- a/src/RemoteConfig/Platforms/Android/Extensions/JavaObjectExtensions.cs
+++ b/src/RemoteConfig/Platforms/Android/Extensions/JavaObjectExtensions.cs
@@ -6,7 +6,7 @@ namespace Plugin.Firebase.RemoteConfig.Platforms.Android.Extensions;
 
 public static class JavaObjectExtensions
 {
-    public static object ToObject(this Java.Lang.Object @this, Type targetType = null)
+    public static object ToObject(this Java.Lang.Object @this, Type? targetType = null)
     {
         switch(@this) {
             case Java.Lang.ICharSequence x:
@@ -34,7 +34,7 @@ public static class JavaObjectExtensions
     {
         switch(@this) {
             case string x:
-                return x;
+                return new Java.Lang.String(x);
             case int x:
                 return x;
             case long x:

--- a/src/RemoteConfig/Platforms/Android/Extensions/ListExtensions.cs
+++ b/src/RemoteConfig/Platforms/Android/Extensions/ListExtensions.cs
@@ -5,9 +5,16 @@ namespace Plugin.Firebase.RemoteConfig.Platforms.Android.Extensions;
 
 public static class ListExtensions
 {
-    public static IList ToList(this JavaList @this, Type targetType = null)
+    public static IList ToList(this JavaList @this, Type? targetType = null)
     {
-        var list = targetType == null ? new List<object>() : (IList) Activator.CreateInstance(typeof(List<>).MakeGenericType(targetType));
+        var list =
+            targetType == null
+                ? new List<object>()
+                : (IList?) Activator.CreateInstance(typeof(List<>).MakeGenericType(targetType));
+        if(list is null) {
+            throw new InvalidOperationException("Could not create list of type " + targetType);
+        }
+
         for(var i = 0; i < @this.Size(); i++) {
             var value = @this[i];
             if(value is Java.Lang.Object javaValue) {

--- a/src/RemoteConfig/Platforms/iOS/Extensions/DictionaryExtensions.cs
+++ b/src/RemoteConfig/Platforms/iOS/Extensions/DictionaryExtensions.cs
@@ -33,7 +33,7 @@ public static class DictionaryExtensions
 
             foreach(DictionaryEntry entry in dictionary) {
                 PutIntoNSDictionary(
-                    new KeyValuePair<string, object>(entry.Key.ToString(), entry.Value),
+                    new KeyValuePair<string, object?>((string) entry.Key, entry.Value),
                     ref nsDictionary
                 );
             }
@@ -48,7 +48,7 @@ public static class DictionaryExtensions
     }
 
     private static void PutIntoNSDictionary(
-        KeyValuePair<string, object> pair,
+        KeyValuePair<string, object?> pair,
         ref NSMutableDictionary<NSString, NSObject> nsDictionary
     )
     {

--- a/src/RemoteConfig/Platforms/iOS/Extensions/DictionaryExtensions.cs
+++ b/src/RemoteConfig/Platforms/iOS/Extensions/DictionaryExtensions.cs
@@ -33,7 +33,11 @@ public static class DictionaryExtensions
 
             foreach(DictionaryEntry entry in dictionary) {
                 PutIntoNSDictionary(
-                    new KeyValuePair<string, object?>((string) entry.Key, entry.Value),
+                    new KeyValuePair<string, object?>(
+                        Convert.ToString(entry.Key)
+                            ?? throw new InvalidOperationException("Dictionary key conversion returned null."),
+                        entry.Value
+                    ),
                     ref nsDictionary
                 );
             }

--- a/src/RemoteConfig/RemoteConfig.csproj
+++ b/src/RemoteConfig/RemoteConfig.csproj
@@ -4,6 +4,8 @@
         <TargetFrameworks>net9.0;net9.0-android;net9.0-ios</TargetFrameworks>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 

--- a/src/RemoteConfig/Shared/RemoteConfig/CrossFirebaseRemoteConfig.cs
+++ b/src/RemoteConfig/Shared/RemoteConfig/CrossFirebaseRemoteConfig.cs
@@ -5,12 +5,12 @@ namespace Plugin.Firebase.RemoteConfig;
 /// </summary>
 public sealed class CrossFirebaseRemoteConfig
 {
-    private static Lazy<IFirebaseRemoteConfig> _implementation = new Lazy<IFirebaseRemoteConfig>(
+    private static Lazy<IFirebaseRemoteConfig?> _implementation = new Lazy<IFirebaseRemoteConfig?>(
         CreateInstance,
         LazyThreadSafetyMode.PublicationOnly
     );
 
-    private static IFirebaseRemoteConfig CreateInstance()
+    private static IFirebaseRemoteConfig? CreateInstance()
     {
 #if IOS || ANDROID
         return new FirebaseRemoteConfigImplementation();
@@ -50,8 +50,8 @@ public sealed class CrossFirebaseRemoteConfig
     public static void Dispose()
     {
         if(_implementation != null && _implementation.IsValueCreated) {
-            _implementation.Value.Dispose();
-            _implementation = new Lazy<IFirebaseRemoteConfig>(
+            _implementation.Value?.Dispose();
+            _implementation = new Lazy<IFirebaseRemoteConfig?>(
                 CreateInstance,
                 LazyThreadSafetyMode.PublicationOnly
             );

--- a/src/RemoteConfig/Shared/RemoteConfig/RemoteConfigSettings.cs
+++ b/src/RemoteConfig/Shared/RemoteConfig/RemoteConfigSettings.cs
@@ -20,7 +20,7 @@ public sealed class RemoteConfigSettings
     }
 
     /// <inheritdoc />
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if(obj is RemoteConfigSettings other) {
             return (MinimumFetchInterval, FetchTimeout).Equals(


### PR DESCRIPTION
## Summary
- Enable nullable analysis and warnings-as-errors for Plugin.Firebase.RemoteConfig.
- Annotate the shared RemoteConfig unsupported-platform implementation path.
- Update RemoteConfig settings and conversion helpers so nullable analysis matches the wrapper and native binding contracts.
- Annotate the Android Core TryGetDefaultApp out parameter so clean RemoteConfig Android builds do not inherit a referenced-project nullable warning.

## Validation
- dotnet build src/RemoteConfig/RemoteConfig.csproj -c Release -f net9.0 --no-restore --no-incremental
- dotnet build src/RemoteConfig/RemoteConfig.csproj -c Release -f net9.0-android --no-restore --no-incremental
- dotnet build src/RemoteConfig/RemoteConfig.csproj -c Release -f net9.0-ios --no-restore --no-incremental