### PR TITLE
[codex] Add Remote Config real-time updates

### DIFF
--- a/docs/remote_config.md
+++ b/docs/remote_config.md
@@ -17,11 +17,28 @@ You can use Firebase Remote Config to define parameters in your app and update t
 
 Take a look at the [documentation](https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/blob/master/docs/Firebase/RemoteConfig/GettingStarted.md) for the AdamE.Firebase.iOS.RemoteConfig packages, because Plugin.Firebase's code is abstracted but still very similar.
 
+Register a real-time update listener when you want Firebase to notify the app that published Remote Config values changed. The listener returns the changed keys; call `ActivateAsync()` explicitly when your app is ready to apply fetched values.
+
+```csharp
+var registration = CrossFirebaseRemoteConfig.Current.AddOnConfigUpdateListener(
+    update => {
+        if(update.UpdatedKeys.Contains("some_remote_config_key")) {
+            _ = CrossFirebaseRemoteConfig.Current.ActivateAsync();
+        }
+    },
+    error => Console.WriteLine(error));
+
+registration.Dispose();
+```
+
 Since code should be documenting itself you can also take a look at the following classes:
 - [src/.../IFirebaseRemoteConfig.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/RemoteConfig/IFirebaseRemoteConfig.cs)
 - [tests/.../RemoteConfigFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/Plugin.Firebase.IntegrationTests/RemoteConfig/RemoteConfigFixture.cs)
 
 ## Release notes
+- Version 4.0.0
+  - Add real-time Remote Config update listener
+  - Using AdamE.Firebase.iOS.* minimum version 12.7.0
 - Version 3.1.1
   - Using AdamE.Firebase.iOS.* minimum version 11
 - Version 3.1.0

--- a/src/RemoteConfig/Platforms/Android/ConfigUpdateListener.cs
+++ b/src/RemoteConfig/Platforms/Android/ConfigUpdateListener.cs
@@ -1,0 +1,40 @@
+using Firebase.RemoteConfig;
+using Plugin.Firebase.Core.Exceptions;
+using Object = Java.Lang.Object;
+
+namespace Plugin.Firebase.RemoteConfig.Platforms.Android;
+
+internal sealed class ConfigUpdateListener : Object, IConfigUpdateListener
+{
+    private readonly Action<RemoteConfigUpdate> _onUpdate;
+    private readonly Action<Exception>? _onError;
+
+    public ConfigUpdateListener(
+        Action<RemoteConfigUpdate> onUpdate,
+        Action<Exception>? onError
+    )
+    {
+        _onUpdate = onUpdate;
+        _onError = onError;
+    }
+
+    public void OnUpdate(ConfigUpdate configUpdate)
+    {
+        _onUpdate(ToAbstract(configUpdate));
+    }
+
+    public void OnError(FirebaseRemoteConfigException? error)
+    {
+        _onError?.Invoke(ToAbstract(error));
+    }
+
+    internal static RemoteConfigUpdate ToAbstract(ConfigUpdate configUpdate)
+    {
+        return new RemoteConfigUpdate(configUpdate.UpdatedKeys.ToArray());
+    }
+
+    internal static FirebaseException ToAbstract(FirebaseRemoteConfigException? error)
+    {
+        return new FirebaseException(error?.LocalizedMessage ?? "Unknown Remote Config update error");
+    }
+}

--- a/src/RemoteConfig/Platforms/Android/FirebaseRemoteConfigImplementation.cs
+++ b/src/RemoteConfig/Platforms/Android/FirebaseRemoteConfigImplementation.cs
@@ -1,6 +1,7 @@
 using Android.Gms.Extensions;
 using Firebase.RemoteConfig;
 using Plugin.Firebase.Core;
+using Plugin.Firebase.RemoteConfig.Platforms.Android;
 using Plugin.Firebase.RemoteConfig.Platforms.Android.Extensions;
 
 namespace Plugin.Firebase.RemoteConfig;
@@ -47,6 +48,13 @@ public sealed class FirebaseRemoteConfigImplementation : DisposableBase, IFireba
     public Task ActivateAsync()
     {
         return _remoteConfig.Activate().AsAsync();
+    }
+
+    public IDisposable AddOnConfigUpdateListener(Action<RemoteConfigUpdate> onUpdate, Action<Exception>? onError = null)
+    {
+        var listener = new ConfigUpdateListener(onUpdate, onError);
+        var registration = _remoteConfig.AddOnConfigUpdateListener(listener);
+        return new DisposableWithAction(registration.Remove);
     }
 
     public IEnumerable<string> GetKeysByPrefix(string prefix)

--- a/src/RemoteConfig/Platforms/iOS/ConfigUpdateListener.cs
+++ b/src/RemoteConfig/Platforms/iOS/ConfigUpdateListener.cs
@@ -1,0 +1,34 @@
+using Foundation;
+using Plugin.Firebase.Core.Exceptions;
+using NativeRemoteConfigUpdate = global::Firebase.RemoteConfig.RemoteConfigUpdate;
+
+namespace Plugin.Firebase.RemoteConfig.Platforms.iOS;
+
+internal static class ConfigUpdateListener
+{
+    internal static void OnConfigUpdate(
+        NativeRemoteConfigUpdate? configUpdate,
+        NSError? error,
+        Action<RemoteConfigUpdate> onUpdate,
+        Action<Exception>? onError
+    )
+    {
+        if(error != null) {
+            onError?.Invoke(ToAbstract(error));
+        } else if(configUpdate != null) {
+            onUpdate(ToAbstract(configUpdate.UpdatedKeys));
+        } else {
+            onError?.Invoke(new FirebaseException("Remote Config update is null"));
+        }
+    }
+
+    internal static RemoteConfigUpdate ToAbstract(NSSet<NSString> updatedKeys)
+    {
+        return new RemoteConfigUpdate(updatedKeys.ToArray().Select(x => (string) x).ToArray());
+    }
+
+    internal static FirebaseException ToAbstract(NSError error)
+    {
+        return new FirebaseException(error.LocalizedDescription ?? "Unknown Remote Config update error");
+    }
+}

--- a/src/RemoteConfig/Platforms/iOS/FirebaseRemoteConfigImplementation.cs
+++ b/src/RemoteConfig/Platforms/iOS/FirebaseRemoteConfigImplementation.cs
@@ -1,4 +1,5 @@
 using Plugin.Firebase.Core;
+using Plugin.Firebase.RemoteConfig.Platforms.iOS;
 using Plugin.Firebase.RemoteConfig.Platforms.iOS.Extensions;
 using FirebaseRemoteConfig = Firebase.RemoteConfig.RemoteConfig;
 
@@ -62,6 +63,14 @@ public sealed class FirebaseRemoteConfigImplementation : DisposableBase, IFireba
     public Task ActivateAsync()
     {
         return _remoteConfig.ActivateAsync();
+    }
+
+    /// <inheritdoc/>
+    public IDisposable AddOnConfigUpdateListener(Action<RemoteConfigUpdate> onUpdate, Action<Exception>? onError = null)
+    {
+        var registration = _remoteConfig.AddOnConfigUpdateListener((configUpdate, error) =>
+            ConfigUpdateListener.OnConfigUpdate(configUpdate, error, onUpdate, onError));
+        return new DisposableWithAction(registration.Remove);
     }
 
     /// <inheritdoc/>

--- a/src/RemoteConfig/Shared/GlobalUsings.cs
+++ b/src/RemoteConfig/Shared/GlobalUsings.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Plugin.Firebase.IntegrationTests")]

--- a/src/RemoteConfig/Shared/RemoteConfig/IFirebaseRemoteConfig.cs
+++ b/src/RemoteConfig/Shared/RemoteConfig/IFirebaseRemoteConfig.cs
@@ -51,6 +51,14 @@ public interface IFirebaseRemoteConfig : IDisposable
     Task ActivateAsync();
 
     /// <summary>
+    /// Registers a listener for real-time Remote Config updates.
+    /// </summary>
+    /// <param name="onUpdate">Callback invoked with the updated parameter keys.</param>
+    /// <param name="onError">Optional callback invoked when the listener fails.</param>
+    /// <returns>A disposable registration that removes the listener when disposed.</returns>
+    IDisposable AddOnConfigUpdateListener(Action<RemoteConfigUpdate> onUpdate, Action<Exception>? onError = null);
+
+    /// <summary>
     /// Returns the set of parameter keys that start with the given prefix, from the default namespace in the active config.
     /// </summary>
     /// <param name="prefix">The key prefix to look for. If prefix is null or empty, returns all the keys.</param>

--- a/src/RemoteConfig/Shared/RemoteConfig/RemoteConfigUpdate.cs
+++ b/src/RemoteConfig/Shared/RemoteConfig/RemoteConfigUpdate.cs
@@ -1,0 +1,21 @@
+namespace Plugin.Firebase.RemoteConfig;
+
+/// <summary>
+/// Represents a real-time Remote Config update.
+/// </summary>
+public sealed class RemoteConfigUpdate
+{
+    /// <summary>
+    /// Creates a new <c>RemoteConfigUpdate</c> instance.
+    /// </summary>
+    /// <param name="updatedKeys">Remote Config parameter keys that changed in the update.</param>
+    public RemoteConfigUpdate(IEnumerable<string> updatedKeys)
+    {
+        UpdatedKeys = updatedKeys;
+    }
+
+    /// <summary>
+    /// Gets the Remote Config parameter keys that changed in the update.
+    /// </summary>
+    public IEnumerable<string> UpdatedKeys { get; }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/RemoteConfig/RemoteConfigFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/RemoteConfig/RemoteConfigFixture.cs
@@ -1,4 +1,14 @@
+using Plugin.Firebase.Core.Exceptions;
 using Plugin.Firebase.RemoteConfig;
+#if ANDROID
+using Firebase.RemoteConfig;
+using Plugin.Firebase.RemoteConfig.Platforms.Android;
+#elif IOS
+using Plugin.Firebase.RemoteConfig.Platforms.iOS;
+using NSError = Foundation.NSError;
+using NSString = Foundation.NSString;
+using NSStringSet = Foundation.NSSet<Foundation.NSString>;
+#endif
 
 namespace Plugin.Firebase.IntegrationTests.RemoteConfig
 {
@@ -93,6 +103,88 @@ namespace Plugin.Firebase.IntegrationTests.RemoteConfig
             Assert.Equal(13.37, sut.GetDouble("remote_double"));
             Assert.True(sut.GetBoolean("remote_bool"));
         }
+
+        [RealFirebaseFact]
+        public void registers_and_disposes_config_update_listener()
+        {
+            IDisposable registration = null;
+
+            try {
+                registration = CrossFirebaseRemoteConfig.Current.AddOnConfigUpdateListener(
+                    _ => { },
+                    _ => { });
+
+                Assert.NotNull(registration);
+            }
+            finally {
+                registration?.Dispose();
+            }
+        }
+
+#if ANDROID
+        [Fact]
+        public void android_config_update_listener_maps_updated_keys()
+        {
+            RemoteConfigUpdate update = null;
+            Exception error = null;
+            var listener = new ConfigUpdateListener(
+                x => update = x,
+                x => error = x);
+            var updatedKeys = new[] { "remote_string", "remote_bool" };
+
+            listener.OnUpdate(ConfigUpdate.Create(updatedKeys));
+
+            Assert.Null(error);
+            Assert.NotNull(update);
+            Assert.Equal(
+                new[] { "remote_bool", "remote_string" },
+                update.UpdatedKeys.OrderBy(x => x).ToArray());
+        }
+
+        [Fact]
+        public void android_config_update_listener_maps_errors()
+        {
+            RemoteConfigUpdate update = null;
+            Exception error = null;
+            var listener = new ConfigUpdateListener(
+                x => update = x,
+                x => error = x);
+            using var nativeError = new FirebaseRemoteConfigException(
+                "real-time update failed",
+                FirebaseRemoteConfigException.Code.ConfigUpdateUnavailable);
+
+            listener.OnError(nativeError);
+
+            Assert.Null(update);
+            var firebaseException = Assert.IsType<FirebaseException>(error);
+            Assert.Equal("real-time update failed", firebaseException.Message);
+        }
+#elif IOS
+        [Fact]
+        public void ios_config_update_listener_maps_updated_keys()
+        {
+            using var firstKey = new NSString("remote_string");
+            using var secondKey = new NSString("remote_bool");
+            using var updatedKeys = new NSStringSet(new[] { firstKey, secondKey });
+
+            var update = ConfigUpdateListener.ToAbstract(updatedKeys);
+
+            Assert.Equal(
+                new[] { "remote_bool", "remote_string" },
+                update.UpdatedKeys.OrderBy(x => x).ToArray());
+        }
+
+        [Fact]
+        public void ios_config_update_listener_maps_errors()
+        {
+            using var domain = new NSString("remote.config.test");
+            using var nativeError = new NSError(domain, new IntPtr(7));
+
+            var firebaseException = ConfigUpdateListener.ToAbstract(nativeError);
+
+            Assert.Equal(nativeError.LocalizedDescription, firebaseException.Message);
+        }
+#endif
 
         private static string GetExpectedActivationErrorMessage()
         {


### PR DESCRIPTION
## Summary
- Add cross-platform Firebase Remote Config real-time update listener support.
- Add `RemoteConfigUpdate` and `IFirebaseRemoteConfig.AddOnConfigUpdateListener(...)`.
- Map native Android/iOS update keys and listener errors into plugin abstractions.
- Update Remote Config docs and add deterministic integration coverage for listener adapters.

## Validation
- `dotnet restore Plugin.Firebase.sln`
- `dotnet build src/RemoteConfig/RemoteConfig.csproj -c Release -f net9.0`
- `dotnet build src/RemoteConfig/RemoteConfig.csproj -c Release -f net9.0-android`
- `dotnet build src/RemoteConfig/RemoteConfig.csproj -c Release -f net9.0-ios`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Release -f net9.0-android`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false`
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj`
- `git diff --check`

## Notes
- The exact Release iOS integration-app build without simulator/signing overrides is blocked locally by missing provisioning profiles for `Plugin.Firebase.IntegrationTests`.
- The tests intentionally do not assert that a live Remote Config update arrives, because that requires publishing console changes during the test run.