### PR TITLE
[codex] Fix callable response JSON serialization

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -308,6 +308,13 @@ Required functions:
 | Function | Type | Purpose |
 |---|---|---|
 | `convertToLeet` | `https.onCall` | Called by `FunctionsFixture` |
+| `returnObjectPayload` | `https.onCall` | Verifies callable object response deserialization |
+| `returnArrayPayload` | `https.onCall` | Verifies callable array response deserialization |
+| `returnStringPayload` | `https.onCall` | Verifies callable string response deserialization |
+| `returnEscapedStringPayload` | `https.onCall` | Verifies callable escaped string response deserialization |
+| `returnNumberPayload` | `https.onCall` | Verifies callable number response deserialization |
+| `returnBooleanPayload` | `https.onCall` | Verifies callable boolean response deserialization |
+| `returnNullPayload` | `https.onCall` | Verifies callable null response deserialization |
 | `addMessage` | `https.onRequest` | Writes to Firestore `messages` collection |
 | `makeUppercase` | `firestore.onCreate` | Triggered on `/messages/{documentId}` |
 | `echo` | `https.onRequest` | Echoes request body |

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -26,6 +26,8 @@ Since code should be documenting itself you can also take a look at the followin
 - [tests/cloud-functions/.../index.ts](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/cloud-functions/functions/src/index.ts)
 
 ## Release notes
+- Version 4.0.0
+  - Fixed typed callable responses for native object, array, scalar, and null payloads
 - Version 3.1.1
   - Using AdamE.Firebase.iOS.* minimum version 11
 - Version 3.1.0

--- a/src/Functions/Platforms/Android/HttpsCallableWrapper.cs
+++ b/src/Functions/Platforms/Android/HttpsCallableWrapper.cs
@@ -34,6 +34,62 @@ public sealed class HttpsCallableWrapper : IHttpsCallable
     public async Task<TResponse> CallAsync<TResponse>(string dataJson = null)
     {
         var result = await _httpsCallable.Call(ConvertJsonToData(dataJson)).AsAsync<HttpsCallableResult>();
-        return JsonSerializer.Deserialize<TResponse>(result.Data.ToString());
+        return DeserializeResponse<TResponse>(result.Data);
+    }
+
+    private static TResponse DeserializeResponse<TResponse>(Java.Lang.Object data)
+    {
+        if(data == null) {
+            return default;
+        }
+
+        if(data is Java.Lang.String stringData) {
+            return DeserializeStringResponse<TResponse>(stringData.ToString());
+        }
+
+        var json = ConvertDataToJson(data);
+        if(json == null) {
+            return default;
+        }
+
+        if(typeof(TResponse) == typeof(string)) {
+            return (TResponse) (object) json;
+        }
+
+        return JsonSerializer.Deserialize<TResponse>(json);
+    }
+
+    private static TResponse DeserializeStringResponse<TResponse>(string value)
+    {
+        if(value == null) {
+            return default;
+        }
+
+        if(typeof(TResponse) == typeof(string)) {
+            return (TResponse) (object) value;
+        }
+
+        var json = IsJson(value)
+            ? value
+            : JsonSerializer.Serialize(value);
+        return JsonSerializer.Deserialize<TResponse>(json);
+    }
+
+    private static bool IsJson(string value)
+    {
+        try {
+            using var _ = JsonDocument.Parse(value);
+            return true;
+        } catch(JsonException) {
+            return false;
+        }
+    }
+
+    private static string ConvertDataToJson(Java.Lang.Object data)
+    {
+        return data switch {
+            null => null,
+            _ => new Gson().ToJson(data)
+        };
     }
 }

--- a/src/Functions/Platforms/iOS/HttpsCallableWrapper.cs
+++ b/src/Functions/Platforms/iOS/HttpsCallableWrapper.cs
@@ -9,6 +9,9 @@ namespace Plugin.Firebase.Functions.Platforms.iOS;
 /// </summary>
 public sealed class HttpsCallableWrapper : IHttpsCallable
 {
+    // The current .NET iOS enum binding does not expose NSJSONWritingFragmentsAllowed.
+    private const NSJsonWritingOptions JsonWritingFragmentsAllowed = (NSJsonWritingOptions) 4;
+
     private readonly HttpsCallable _httpsCallable;
 
     /// <summary>
@@ -44,7 +47,76 @@ public sealed class HttpsCallableWrapper : IHttpsCallable
     /// <inheritdoc/>
     public async Task<TResponse> CallAsync<TResponse>(string dataJson = null)
     {
-        var result = await _httpsCallable.CallAsync(ConvertJsonToData(dataJson));
-        return JsonSerializer.Deserialize<TResponse>(result.Data.ToString());
+        var result = dataJson == null
+            ? await _httpsCallable.CallAsync()
+            : await _httpsCallable.CallAsync(ConvertJsonToData(dataJson));
+        return DeserializeResponse<TResponse>(result.Data);
+    }
+
+    private static TResponse DeserializeResponse<TResponse>(NSObject data)
+    {
+        if(data == null || data == NSNull.Null) {
+            return default;
+        }
+
+        if(data is NSString stringData) {
+            return DeserializeStringResponse<TResponse>(stringData.ToString());
+        }
+
+        var json = ConvertDataToJson(data);
+        if(json == null) {
+            return default;
+        }
+
+        if(typeof(TResponse) == typeof(string)) {
+            return (TResponse) (object) json;
+        }
+
+        return JsonSerializer.Deserialize<TResponse>(json);
+    }
+
+    private static TResponse DeserializeStringResponse<TResponse>(string value)
+    {
+        if(value == null) {
+            return default;
+        }
+
+        if(typeof(TResponse) == typeof(string)) {
+            return (TResponse) (object) value;
+        }
+
+        var json = IsJson(value)
+            ? value
+            : JsonSerializer.Serialize(value);
+        return JsonSerializer.Deserialize<TResponse>(json);
+    }
+
+    private static bool IsJson(string value)
+    {
+        try {
+            using var _ = JsonDocument.Parse(value);
+            return true;
+        } catch(JsonException) {
+            return false;
+        }
+    }
+
+    private static string ConvertDataToJson(NSObject data)
+    {
+        if(data == null || data == NSNull.Null) {
+            return null;
+        }
+
+        var jsonData = NSJsonSerialization.Serialize(
+            data,
+            JsonWritingFragmentsAllowed,
+            out var error);
+        if(error != null) {
+            throw new FirebaseException(error.LocalizedDescription);
+        }
+
+        return jsonData == null
+            ? null
+            : NSString.FromData(jsonData, NSStringEncoding.UTF8)?.ToString();
     }
 }

--- a/src/Functions/Platforms/iOS/HttpsCallableWrapper.cs
+++ b/src/Functions/Platforms/iOS/HttpsCallableWrapper.cs
@@ -9,9 +9,6 @@ namespace Plugin.Firebase.Functions.Platforms.iOS;
 /// </summary>
 public sealed class HttpsCallableWrapper : IHttpsCallable
 {
-    // The current .NET iOS enum binding does not expose NSJSONWritingFragmentsAllowed.
-    private const NSJsonWritingOptions JsonWritingFragmentsAllowed = (NSJsonWritingOptions) 4;
-
     private readonly HttpsCallable _httpsCallable;
 
     /// <summary>
@@ -109,7 +106,7 @@ public sealed class HttpsCallableWrapper : IHttpsCallable
 
         var jsonData = NSJsonSerialization.Serialize(
             data,
-            JsonWritingFragmentsAllowed,
+            NSJsonWritingOptions.FragmentsAllowed,
             out var error);
         if(error != null) {
             throw new FirebaseException(error.LocalizedDescription);

--- a/tests/Plugin.Firebase.IntegrationTests/Functions/CallableObjectResponseData.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Functions/CallableObjectResponseData.cs
@@ -1,0 +1,64 @@
+using System.Text.Json.Serialization;
+
+namespace Plugin.Firebase.IntegrationTests.Functions
+{
+    [Preserve(AllMembers = true)]
+    public sealed class CallableObjectResponseData
+    {
+        public CallableObjectResponseData()
+        {
+        }
+
+        [JsonPropertyName("input_value")]
+        public long InputValue { get; set; }
+
+        [JsonPropertyName("output_value")]
+        public long OutputValue { get; set; }
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; }
+
+        [JsonPropertyName("is_valid")]
+        public bool IsValid { get; set; }
+
+        [JsonPropertyName("nested")]
+        public CallableNestedResponseData Nested { get; set; }
+
+        [JsonPropertyName("items")]
+        public List<CallableArrayItemData> Items { get; set; }
+
+        [JsonPropertyName("tags")]
+        public List<string> Tags { get; set; }
+
+        [JsonPropertyName("scores")]
+        public List<long> Scores { get; set; }
+    }
+
+    [Preserve(AllMembers = true)]
+    public sealed class CallableNestedResponseData
+    {
+        public CallableNestedResponseData()
+        {
+        }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("count")]
+        public long Count { get; set; }
+    }
+
+    [Preserve(AllMembers = true)]
+    public sealed class CallableArrayItemData
+    {
+        public CallableArrayItemData()
+        {
+        }
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; }
+
+        [JsonPropertyName("value")]
+        public long Value { get; set; }
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/Functions/FunctionsFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Functions/FunctionsFixture.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Plugin.Firebase.Functions;
 
 namespace Plugin.Firebase.IntegrationTests.Functions
@@ -34,10 +35,242 @@ namespace Plugin.Firebase.IntegrationTests.Functions
         }
 
         [Fact]
+        public async Task deserializes_callable_function_with_json_string_response_as_raw_string_and_json_value()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+            var json = new SimpleRequestData(123).ToJson();
+
+            var responseJson = await sut.GetHttpsCallable("convertToLeet").CallAsync<string>(json);
+            using var response = JsonDocument.Parse(responseJson);
+            AssertSimpleResponse(response.RootElement, 123);
+
+            var responseElement = await sut.GetHttpsCallable("convertToLeet").CallAsync<JsonElement>(json);
+            AssertSimpleResponse(responseElement, 123);
+        }
+
+        [Fact]
+        public async Task deserializes_callable_function_with_native_object_response()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+            var json = new SimpleRequestData(123).ToJson();
+            var response = await sut.GetHttpsCallable("returnObjectPayload").CallAsync<CallableObjectResponseData>(json);
+
+            AssertObjectResponse(response, 123);
+        }
+
+        [Fact]
+        public async Task deserializes_callable_function_with_native_object_response_without_json_body()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+            var response = await sut.GetHttpsCallable("returnObjectPayload").CallAsync<CallableObjectResponseData>();
+
+            AssertObjectResponse(response, 0);
+        }
+
+        [Fact]
+        public async Task returns_callable_native_object_response_as_json_string()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+            var json = new SimpleRequestData(123).ToJson();
+            var responseJson = await sut.GetHttpsCallable("returnObjectPayload").CallAsync<string>(json);
+
+            using var response = JsonDocument.Parse(responseJson);
+            var root = response.RootElement;
+            Assert.Equal(123, root.GetProperty("input_value").GetInt64());
+            Assert.Equal(1337, root.GetProperty("output_value").GetInt64());
+            Assert.Equal("object response", root.GetProperty("message").GetString());
+            Assert.True(root.GetProperty("is_valid").GetBoolean());
+            Assert.Equal("nested response", root.GetProperty("nested").GetProperty("name").GetString());
+            Assert.Equal(2, root.GetProperty("items").GetArrayLength());
+        }
+
+        [Fact]
+        public async Task deserializes_callable_function_with_native_object_response_as_json_value()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+            var json = new SimpleRequestData(123).ToJson();
+            var response = await sut.GetHttpsCallable("returnObjectPayload").CallAsync<JsonElement>(json);
+
+            AssertObjectJsonElement(response, 123);
+        }
+
+        [Fact]
+        public async Task deserializes_callable_function_with_native_array_response()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+            var response = await sut.GetHttpsCallable("returnArrayPayload").CallAsync<List<CallableArrayItemData>>();
+
+            Assert.Collection(
+                response,
+                first => {
+                    Assert.Equal("first", first.Title);
+                    Assert.Equal(1, first.Value);
+                },
+                second => {
+                    Assert.Equal("second", second.Title);
+                    Assert.Equal(2, second.Value);
+                });
+        }
+
+        [Fact]
+        public async Task deserializes_callable_function_with_native_array_response_as_json_string_and_json_value()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+
+            var responseJson = await sut.GetHttpsCallable("returnArrayPayload").CallAsync<string>();
+            using var response = JsonDocument.Parse(responseJson);
+            AssertArrayJsonElement(response.RootElement);
+
+            var responseElement = await sut.GetHttpsCallable("returnArrayPayload").CallAsync<JsonElement>();
+            AssertArrayJsonElement(responseElement);
+        }
+
+        [Fact]
+        public async Task deserializes_callable_function_with_native_string_response()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+            var response = await sut.GetHttpsCallable("returnStringPayload").CallAsync<string>();
+
+            Assert.Equal("callable-string", response);
+        }
+
+        [Fact]
+        public async Task deserializes_callable_function_with_native_string_response_as_json_value()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+            var response = await sut.GetHttpsCallable("returnStringPayload").CallAsync<JsonElement>();
+
+            Assert.Equal(JsonValueKind.String, response.ValueKind);
+            Assert.Equal("callable-string", response.GetString());
+        }
+
+        [Fact]
+        public async Task deserializes_callable_function_with_native_escaped_string_response()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+            const string expected = "escaped \"quote\" and backslash \\\\ path";
+
+            var response = await sut.GetHttpsCallable("returnEscapedStringPayload").CallAsync<string>();
+            Assert.Equal(expected, response);
+
+            var responseElement = await sut.GetHttpsCallable("returnEscapedStringPayload").CallAsync<JsonElement>();
+            Assert.Equal(JsonValueKind.String, responseElement.ValueKind);
+            Assert.Equal(expected, responseElement.GetString());
+        }
+
+        [Fact]
+        public async Task deserializes_callable_function_with_native_number_response()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+            var response = await sut.GetHttpsCallable("returnNumberPayload").CallAsync<long>();
+
+            Assert.Equal(42, response);
+        }
+
+        [Fact]
+        public async Task deserializes_callable_function_with_native_number_response_as_json_string_and_json_value()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+
+            Assert.Equal("42", await sut.GetHttpsCallable("returnNumberPayload").CallAsync<string>());
+
+            var response = await sut.GetHttpsCallable("returnNumberPayload").CallAsync<JsonElement>();
+            Assert.Equal(JsonValueKind.Number, response.ValueKind);
+            Assert.Equal(42, response.GetInt64());
+        }
+
+        [Fact]
+        public async Task deserializes_callable_function_with_native_boolean_response()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+            var response = await sut.GetHttpsCallable("returnBooleanPayload").CallAsync<bool>();
+
+            Assert.True(response);
+        }
+
+        [Fact]
+        public async Task deserializes_callable_function_with_native_boolean_response_as_json_string_and_json_value()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+
+            Assert.Equal("true", await sut.GetHttpsCallable("returnBooleanPayload").CallAsync<string>());
+
+            var response = await sut.GetHttpsCallable("returnBooleanPayload").CallAsync<JsonElement>();
+            Assert.Equal(JsonValueKind.True, response.ValueKind);
+            Assert.True(response.GetBoolean());
+        }
+
+        [Fact]
+        public async Task returns_default_for_callable_function_with_native_null_response()
+        {
+            var sut = CrossFirebaseFunctions.Current;
+
+            Assert.Null(await sut.GetHttpsCallable("returnNullPayload").CallAsync<CallableObjectResponseData>());
+            Assert.Null(await sut.GetHttpsCallable("returnNullPayload").CallAsync<string>());
+            Assert.Equal(default, await sut.GetHttpsCallable("returnNullPayload").CallAsync<long>());
+            Assert.Equal(JsonValueKind.Undefined, (await sut.GetHttpsCallable("returnNullPayload").CallAsync<JsonElement>()).ValueKind);
+        }
+
+        [Fact]
         public async Task throws_exception_when_function_does_not_exist()
         {
             var sut = CrossFirebaseFunctions.Current;
             await Assert.ThrowsAnyAsync<Exception>(() => sut.GetHttpsCallable("doesNotExist").CallAsync());
+        }
+
+        private static void AssertSimpleResponse(JsonElement response, long expectedInputValue)
+        {
+            Assert.Equal(JsonValueKind.Object, response.ValueKind);
+            Assert.Equal(expectedInputValue, response.GetProperty("input_value").GetInt64());
+            Assert.Equal(1337, response.GetProperty("output_value").GetInt64());
+        }
+
+        private static void AssertObjectResponse(CallableObjectResponseData response, long expectedInputValue)
+        {
+            Assert.NotNull(response);
+            Assert.Equal(expectedInputValue, response.InputValue);
+            Assert.Equal(1337, response.OutputValue);
+            Assert.Equal("object response", response.Message);
+            Assert.True(response.IsValid);
+            Assert.NotNull(response.Nested);
+            Assert.Equal("nested response", response.Nested.Name);
+            Assert.Equal(2, response.Nested.Count);
+            Assert.Collection(
+                response.Items,
+                first => {
+                    Assert.Equal("first", first.Title);
+                    Assert.Equal(1, first.Value);
+                },
+                second => {
+                    Assert.Equal("second", second.Title);
+                    Assert.Equal(2, second.Value);
+                });
+            Assert.Equal(new[] { "alpha", "beta" }, response.Tags);
+            Assert.Equal(new long[] { 3, 5, 8 }, response.Scores);
+        }
+
+        private static void AssertObjectJsonElement(JsonElement response, long expectedInputValue)
+        {
+            Assert.Equal(JsonValueKind.Object, response.ValueKind);
+            Assert.Equal(expectedInputValue, response.GetProperty("input_value").GetInt64());
+            Assert.Equal(1337, response.GetProperty("output_value").GetInt64());
+            Assert.Equal("object response", response.GetProperty("message").GetString());
+            Assert.True(response.GetProperty("is_valid").GetBoolean());
+            Assert.Equal("nested response", response.GetProperty("nested").GetProperty("name").GetString());
+            Assert.Equal(2, response.GetProperty("nested").GetProperty("count").GetInt64());
+            AssertArrayJsonElement(response.GetProperty("items"));
+            Assert.Equal(new[] { "alpha", "beta" }, response.GetProperty("tags").EnumerateArray().Select(x => x.GetString()));
+            Assert.Equal(new long[] { 3, 5, 8 }, response.GetProperty("scores").EnumerateArray().Select(x => x.GetInt64()));
+        }
+
+        private static void AssertArrayJsonElement(JsonElement response)
+        {
+            Assert.Equal(JsonValueKind.Array, response.ValueKind);
+            Assert.Equal(2, response.GetArrayLength());
+            Assert.Equal("first", response[0].GetProperty("title").GetString());
+            Assert.Equal(1, response[0].GetProperty("value").GetInt64());
+            Assert.Equal("second", response[1].GetProperty("title").GetString());
+            Assert.Equal(2, response[1].GetProperty("value").GetInt64());
         }
     }
 }

--- a/tests/cloud-functions/functions/src/index.ts
+++ b/tests/cloud-functions/functions/src/index.ts
@@ -22,6 +22,72 @@ exports.convertToLeet = functions.https.onCall(async (data, context) =>  {
   return `{ "input_value": ${data?.input_value}, "output_value": 1337 }`;
 });
 
+exports.returnObjectPayload = functions.https.onCall(async (data, context) =>  {
+  functions.logger.log('[+] returnObjectPayload:', data);
+  const inputValue = data?.input_value ?? 0;
+  return {
+    input_value: inputValue,
+    output_value: 1337,
+    message: 'object response',
+    is_valid: true,
+    nested: {
+      name: 'nested response',
+      count: 2,
+    },
+    items: [
+      {
+        title: 'first',
+        value: 1,
+      },
+      {
+        title: 'second',
+        value: 2,
+      },
+    ],
+    tags: ['alpha', 'beta'],
+    scores: [3, 5, 8],
+  };
+});
+
+exports.returnArrayPayload = functions.https.onCall(async (data, context) =>  {
+  functions.logger.log('[+] returnArrayPayload:', data);
+  return [
+    {
+      title: 'first',
+      value: 1,
+    },
+    {
+      title: 'second',
+      value: 2,
+    },
+  ];
+});
+
+exports.returnStringPayload = functions.https.onCall(async (data, context) =>  {
+  functions.logger.log('[+] returnStringPayload:', data);
+  return 'callable-string';
+});
+
+exports.returnEscapedStringPayload = functions.https.onCall(async (data, context) =>  {
+  functions.logger.log('[+] returnEscapedStringPayload:', data);
+  return 'escaped "quote" and backslash \\\\ path';
+});
+
+exports.returnNumberPayload = functions.https.onCall(async (data, context) =>  {
+  functions.logger.log('[+] returnNumberPayload:', data);
+  return 42;
+});
+
+exports.returnBooleanPayload = functions.https.onCall(async (data, context) =>  {
+  functions.logger.log('[+] returnBooleanPayload:', data);
+  return true;
+});
+
+exports.returnNullPayload = functions.https.onCall(async (data, context) =>  {
+  functions.logger.log('[+] returnNullPayload:', data);
+  return null;
+});
+
 exports.echo = functions.https.onRequest(async (request, response) => {
     functions.logger.log(`[+] echo: headers = ${JSON.stringify(request.headers)}`);
     response.send(request.body);


### PR DESCRIPTION
## Summary
- Fix typed Cloud Functions callable responses by converting native Android/iOS response payloads to JSON before `System.Text.Json` deserialization.
- Preserve existing compatibility for callable functions that return JSON as a string.
- Add emulator-backed integration coverage for object, array, string, escaped string, number, boolean, and null response payloads.

## Root cause
`CallAsync<TResponse>` used `result.Data.ToString()` on native response objects. For native maps/dictionaries and other non-string payloads, that does not produce valid JSON, so typed deserialization could throw `JsonException`.

## Validation
- `npm run build`
- `dotnet format Plugin.Firebase.sln --include tests/Plugin.Firebase.IntegrationTests/Functions/FunctionsFixture.cs`
- `dotnet build src/Functions/Functions.csproj -c Release -f net9.0-android --no-restore`
- `dotnet build src/Functions/Functions.csproj -c Release -f net9.0-ios --no-restore`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-android --no-restore`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:CodesignKey=- --no-restore`
- `git diff --check`

Live device/emulator integration test execution was not run locally.