### PR TITLE
[codex] Add Firestore issue 422 proof test

### DIFF
--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/CrewCheckIn.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/CrewCheckIn.cs
@@ -1,0 +1,180 @@
+using Plugin.Firebase.Firestore;
+
+namespace Plugin.Firebase.IntegrationTests.Firestore
+{
+    public class CrewCheckIn : IFirestoreObject
+    {
+        [Preserve]
+        public CrewCheckIn()
+        {
+        }
+
+        public CrewCheckIn(List<CrewCheckInEmployee> employees, List<CrewCheckInAsset> yardAssets, string clockInTime, string yardLocation, bool emergencyCheckIn, List<CrewCheckInRemovedAsset> removedAssets, List<CrewCheckInLog> logEntries, DateTime timestamp)
+        {
+            Employees = employees;
+            YardAssets = yardAssets;
+            ClockInTime = clockInTime;
+            YardLocation = yardLocation;
+            EmergencyCheckIn = emergencyCheckIn;
+            RemovedAssets = removedAssets;
+            LogEntries = logEntries;
+            Timestamp = timestamp;
+        }
+
+        [FirestoreProperty("employees")]
+        public IList<CrewCheckInEmployee> Employees { get; set; }
+
+        [FirestoreProperty("yardAssets")]
+        public IList<CrewCheckInAsset> YardAssets { get; set; }
+
+        [FirestoreProperty("clockInTime")]
+        public string ClockInTime { get; set; }
+
+        [FirestoreProperty("yardLocation")]
+        public string YardLocation { get; set; }
+
+        [FirestoreProperty("emergencyCheckIn")]
+        public bool EmergencyCheckIn { get; set; }
+
+        [FirestoreProperty("removedAssets")]
+        public IList<CrewCheckInRemovedAsset> RemovedAssets { get; set; }
+
+        [FirestoreProperty("logs")]
+        public IList<CrewCheckInLog> LogEntries { get; set; }
+
+        [FirestoreProperty("timestamp")]
+        public DateTime Timestamp { get; set; }
+    }
+
+    public class CrewCheckInEmployee : IFirestoreObject
+    {
+        [Preserve]
+        public CrewCheckInEmployee()
+        {
+        }
+
+        public CrewCheckInEmployee(string name, string clazz, int crew, List<string> languages, List<CrewCheckInAsset> assignedEquipment, List<CrewCheckInAsset> assignedVehicles, string clockInTime, string status, string workType, List<string> jobNumbers, string notes)
+        {
+            Name = name;
+            Clazz = clazz;
+            Crew = crew;
+            Languages = languages;
+            AssignedEquipment = assignedEquipment;
+            AssignedVehicles = assignedVehicles;
+            ClockInTime = clockInTime;
+            Status = status;
+            WorkType = workType;
+            JobNumbers = jobNumbers;
+            Notes = notes;
+        }
+
+        [FirestoreProperty("name")]
+        public string Name { get; set; }
+
+        [FirestoreProperty("class")]
+        public string Clazz { get; set; }
+
+        [FirestoreProperty("crew")]
+        public int Crew { get; set; }
+
+        [FirestoreProperty("languages")]
+        public IList<string> Languages { get; set; }
+
+        [FirestoreProperty("assignedEquipment")]
+        public IList<CrewCheckInAsset> AssignedEquipment { get; set; }
+
+        [FirestoreProperty("assignedVehicles")]
+        public IList<CrewCheckInAsset> AssignedVehicles { get; set; }
+
+        [FirestoreProperty("clockInTime")]
+        public string ClockInTime { get; set; }
+
+        [FirestoreProperty("status")]
+        public string Status { get; set; }
+
+        [FirestoreProperty("workType")]
+        public string WorkType { get; set; }
+
+        [FirestoreProperty("jobNumbers")]
+        public IList<string> JobNumbers { get; set; }
+
+        [FirestoreProperty("notes")]
+        public string Notes { get; set; }
+    }
+
+    public class CrewCheckInRemovedAsset : IFirestoreObject
+    {
+        [Preserve]
+        public CrewCheckInRemovedAsset()
+        {
+        }
+
+        public CrewCheckInRemovedAsset(string assetName, string assetDescription, string reason)
+        {
+            AssetName = assetName;
+            AssetDescription = assetDescription;
+            Reason = reason;
+        }
+
+        [FirestoreProperty("assetName")]
+        public string AssetName { get; private set; }
+
+        [FirestoreProperty("assetDescription")]
+        public string AssetDescription { get; private set; }
+
+        [FirestoreProperty("reason")]
+        public string Reason { get; private set; }
+    }
+
+    public class CrewCheckInLog : IFirestoreObject
+    {
+        [Preserve]
+        public CrewCheckInLog()
+        {
+        }
+
+        public CrewCheckInLog(DateTime timestamp, string action, string message)
+        {
+            Timestamp = timestamp;
+            Action = action;
+            Message = message;
+        }
+
+        [FirestoreProperty("timestamp")]
+        public DateTime Timestamp { get; set; } // Plugin.Firebase maps to Firestore timestamp
+
+        [FirestoreProperty("action")]
+        public string Action { get; set; }
+
+        [FirestoreProperty("message")]
+        public string Message { get; set; }
+    }
+
+    public class CrewCheckInAsset : IFirestoreObject
+    {
+        [Preserve]
+        public CrewCheckInAsset()
+        {
+        }
+
+        public CrewCheckInAsset(string description, string name, string @operator, string type)
+        {
+            Description = description;
+            Name = name;
+            Operator = @operator;
+            Type = type;
+        }
+
+        [FirestoreProperty("description")]
+        public string Description { get; set; }
+
+        [FirestoreProperty("name")]
+        public string Name { get; set; }
+
+        [FirestoreProperty("operator")]
+        public string Operator { get; set; }
+
+        [FirestoreProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -610,6 +610,92 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         }
 
         [Fact]
+        public async Task reads_issue_422_crew_check_in_document()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var document = GetTestingDocument(sut, "issue-422-crew-check-in");
+            var timestamp = new DateTime(2025, 2, 27, 14, 48, 2, 625, DateTimeKind.Utc);
+            var logTimestamp = new DateTime(2025, 2, 27, 14, 49, 3, 123, DateTimeKind.Utc);
+            var assignedEquipment = new List<CrewCheckInAsset> {
+                new("bucket truck attachment", "Bucket Attachment", "Alice", "equipment")
+            };
+            var assignedVehicles = new List<CrewCheckInAsset> {
+                new("crew truck", "Truck 12", "Bob", "vehicle")
+            };
+            var yardAssets = new List<CrewCheckInAsset> {
+                new("crew truck", "Truck 12", "Bob", "vehicle"),
+                new("compressor", "Air Compressor", "Charlie", "equipment")
+            };
+            var crewCheckIn = new CrewCheckIn(
+                employees: new List<CrewCheckInEmployee> {
+                    new(
+                        "Ada Lovelace",
+                        "Foreman",
+                        7,
+                        new List<string> { "en", "de" },
+                        assignedEquipment,
+                        assignedVehicles,
+                        "07:30",
+                        "checked-in",
+                        "yard",
+                        new List<string> { "1001", "1002" },
+                        "ready")
+                },
+                yardAssets: yardAssets,
+                clockInTime: "07:30",
+                yardLocation: "north yard",
+                emergencyCheckIn: true,
+                removedAssets: new List<CrewCheckInRemovedAsset> {
+                    new("Spare Saw", "damaged chainsaw", "maintenance")
+                },
+                logEntries: new List<CrewCheckInLog> {
+                    new(logTimestamp, "created", "check-in created")
+                },
+                timestamp: timestamp);
+
+            await document.SetDataAsync(crewCheckIn);
+
+            var snapshot = await document.GetDocumentSnapshotAsync<CrewCheckIn>();
+
+            Assert.NotNull(snapshot.Data);
+            Assert.True(snapshot.Data.EmergencyCheckIn);
+            Assert.Equal("07:30", snapshot.Data.ClockInTime);
+            Assert.Equal("north yard", snapshot.Data.YardLocation);
+            Assert.InRange(Math.Abs(snapshot.Data.Timestamp.Ticks - timestamp.Ticks), 0, 10);
+
+            var employee = Assert.Single(snapshot.Data.Employees);
+            Assert.Equal("Ada Lovelace", employee.Name);
+            Assert.Equal("Foreman", employee.Clazz);
+            Assert.Equal(7, employee.Crew);
+            Assert.Equal(new[] { "en", "de" }, employee.Languages);
+            Assert.Equal(new[] { "1001", "1002" }, employee.JobNumbers);
+            Assert.Equal("yard", employee.WorkType);
+            Assert.Equal("ready", employee.Notes);
+
+            var equipment = Assert.Single(employee.AssignedEquipment);
+            Assert.Equal("Bucket Attachment", equipment.Name);
+            Assert.Equal("Alice", equipment.Operator);
+
+            var vehicle = Assert.Single(employee.AssignedVehicles);
+            Assert.Equal("Truck 12", vehicle.Name);
+            Assert.Equal("Bob", vehicle.Operator);
+
+            Assert.Equal(2, snapshot.Data.YardAssets.Count);
+            Assert.Equal("Truck 12", snapshot.Data.YardAssets[0].Name);
+            Assert.Equal("Air Compressor", snapshot.Data.YardAssets[1].Name);
+
+            var removedAsset = Assert.Single(snapshot.Data.RemovedAssets);
+            Assert.Equal("Spare Saw", removedAsset.AssetName);
+            Assert.Equal("damaged chainsaw", removedAsset.AssetDescription);
+            Assert.Equal("maintenance", removedAsset.Reason);
+
+            var log = Assert.Single(snapshot.Data.LogEntries);
+            Assert.Equal("created", log.Action);
+            Assert.Equal("check-in created", log.Message);
+            Assert.InRange(Math.Abs(log.Timestamp.Ticks - logTimestamp.Ticks), 0, 10);
+        }
+
+        [Fact]
         public async Task gets_real_time_updates_on_multiple_documents()
         {
             var sut = CrossFirebaseFirestore.Current;


### PR DESCRIPTION
## Summary
- Adds near-verbatim Firestore POCOs from issue #422 as integration-test models.
- Adds a focused Firestore integration test that writes and reads the nested CrewCheckIn graph through GetDocumentSnapshotAsync<CrewCheckIn>().
- Covers nested lists, nested object maps, private setters, DateTime values, and Firestore field names such as class, operator, yardAssets, assignedEquipment, removedAssets, and logs.

Refs #422.

## Validation
- dotnet format Plugin.Firebase.sln --include tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs tests/Plugin.Firebase.IntegrationTests/Firestore/CrewCheckIn.cs
- dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false
- xharness apple test --target ios-simulator-64 --device F7ED7B62-B4B2-4643-B3F3-F3450EE51E76 --timeout="00:03:00" --launch-timeout="00:03:00" --app tests/Plugin.Firebase.IntegrationTests/bin/Debug/net9.0-ios/iossimulator-arm64/Plugin.Firebase.IntegrationTests.app --output-directory artifacts/test-results/ios-issue-422-crew-check-in-pr --method Plugin.Firebase.IntegrationTests.Firestore.FirestoreFixture.reads_issue_422_crew_check_in_document --verbosity=Debug

The filtered iOS XHarness run passed: Tests run: 1 Passed: 1.