### PR TITLE
[codex] Add Firestore typed map regression coverage

### DIFF
--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -745,6 +745,32 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         }
 
         [Fact]
+        public async Task round_trips_typed_boolean_and_datetime_map_values()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+            var document = GetTestingDocument(sut, "typed-boolean-and-datetime-map-values");
+            var expectedEarlyDate = new DateTimeOffset(2026, 5, 2, 13, 14, 15, 123, TimeSpan.Zero);
+            var expectedLateDate = new DateTimeOffset(2026, 5, 3, 16, 17, 18, 456, TimeSpan.Zero);
+
+            await document.SetDataAsync(new TypedMapValuesDocument(
+                new Dictionary<string, bool> {
+                    { "enabled", true },
+                    { "disabled", false }
+                },
+                new Dictionary<string, DateTimeOffset> {
+                    { "early", expectedEarlyDate },
+                    { "late", expectedLateDate }
+                }));
+
+            var snapshot = await document.GetDocumentSnapshotAsync<TypedMapValuesDocument>(Source.Server);
+
+            Assert.True(snapshot.Data.BooleanMaps["enabled"]);
+            Assert.False(snapshot.Data.BooleanMaps["disabled"]);
+            Assert.Equal(expectedEarlyDate.ToUnixTimeMilliseconds(), snapshot.Data.DateMaps["early"].ToUnixTimeMilliseconds());
+            Assert.Equal(expectedLateDate.ToUnixTimeMilliseconds(), snapshot.Data.DateMaps["late"].ToUnixTimeMilliseconds());
+        }
+
+        [Fact]
         public async Task reads_ios_dictionary_object_numeric_and_boolean_values()
         {
             if(!OperatingSystem.IsIOS()) {
@@ -1654,6 +1680,29 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         private ICollectionReference GetTestingCollection(IFirebaseFirestore firestore)
         {
             return firestore.GetCollection(_testingCollectionPath);
+        }
+
+        [Preserve(AllMembers = true)]
+        private sealed class TypedMapValuesDocument : IFirestoreObject
+        {
+            public TypedMapValuesDocument()
+            {
+                // needed for firestore
+            }
+
+            public TypedMapValuesDocument(
+                Dictionary<string, bool> booleanMaps,
+                Dictionary<string, DateTimeOffset> dateMaps)
+            {
+                BooleanMaps = booleanMaps;
+                DateMaps = dateMaps;
+            }
+
+            [FirestoreProperty("boolean_maps")]
+            public Dictionary<string, bool> BooleanMaps { get; private set; }
+
+            [FirestoreProperty("date_maps")]
+            public Dictionary<string, DateTimeOffset> DateMaps { get; private set; }
         }
 
         [Preserve(AllMembers = true)]

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -766,8 +766,14 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
 
             Assert.True(snapshot.Data.BooleanMaps["enabled"]);
             Assert.False(snapshot.Data.BooleanMaps["disabled"]);
-            Assert.Equal(expectedEarlyDate.ToUnixTimeMilliseconds(), snapshot.Data.DateMaps["early"].ToUnixTimeMilliseconds());
-            Assert.Equal(expectedLateDate.ToUnixTimeMilliseconds(), snapshot.Data.DateMaps["late"].ToUnixTimeMilliseconds());
+            Assert.InRange(
+                Math.Abs(snapshot.Data.DateMaps["early"].Ticks - expectedEarlyDate.Ticks),
+                0,
+                TimeSpan.FromMilliseconds(1).Ticks);
+            Assert.InRange(
+                Math.Abs(snapshot.Data.DateMaps["late"].Ticks - expectedLateDate.Ticks),
+                0,
+                TimeSpan.FromMilliseconds(1).Ticks);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Adds focused Firestore integration coverage for issue #521 by round-tripping typed map values through `SetDataAsync` and `GetDocumentSnapshotAsync<T>()`.

The new regression test verifies `Dictionary<string, bool>` and `Dictionary<string, DateTimeOffset>` values preserve their contents across Android and iOS without platform guards.

## Root Cause

Issue #521 reported platform-specific conversion failures for Firestore map values. Recent conversion fixes cover the behavior, but the integration suite did not include an exact typed bool/date map regression case.

## Validation

- `git diff --check`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`
- `dotnet build src/Firestore/Firestore.csproj -c Release -f net9.0-android --no-restore`

Android build passed with the existing Core nullable warning in `CrossFirebase.cs`.