### PR TITLE
[codex] Add user reauthentication APIs

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -78,7 +78,19 @@ Call `UseAppLanguage()` to reset to the app language.
 ## User reauthentication and reload
 
 Call `CurrentUser.ReauthenticateWithEmailAndPasswordAsync(email, password)` before sensitive email/password user operations that require recent authentication.
-Call `CurrentUser.ReloadAsync()` to refresh that user from the backend, or `ReloadCurrentUserAsync()` to refresh the currently signed in user through `IFirebaseAuth`.
+Call `CurrentUser.ReloadAsync()` to refresh that user from the backend. This is the preferred thin-wrapper API because Firebase exposes reload on the user object.
+
+For example, after sending an email-verification message, reload the user before reading `IsEmailVerified` again:
+
+```csharp
+var user = CrossFirebaseAuth.Current.CurrentUser;
+if(user is not null) {
+    await user.ReloadAsync();
+    var isVerified = user.IsEmailVerified;
+}
+```
+
+`ReloadCurrentUserAsync()` remains available for existing code, but is obsolete. New code should prefer `CurrentUser.ReloadAsync()` after checking `CurrentUser` is not `null`.
 
 ## Error handling
 
@@ -116,6 +128,7 @@ In v5:
 ## Release notes
 - Next
   - Add email/password user reauthentication and user-level reload APIs.
+  - Mark `ReloadCurrentUserAsync()` obsolete; use `CurrentUser.ReloadAsync()` after checking `CurrentUser` is not `null`.
 - Version 5.0.1
   - Fix for wrong Core project version dependency at nuget.org
 - Version 5.0.0

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -75,6 +75,11 @@ Since code should be documenting itself you can also take a look at the followin
 Set `LanguageCode = "fr"` (or any BCP-47 code) before invoking an Auth flow that triggers user-facing content such as password-reset emails, email-verification emails, or phone-auth SMS.
 Call `UseAppLanguage()` to reset to the app language.
 
+## User reauthentication and reload
+
+Call `CurrentUser.ReauthenticateWithEmailAndPasswordAsync(email, password)` before sensitive email/password user operations that require recent authentication.
+Call `CurrentUser.ReloadAsync()` to refresh that user from the backend, or `ReloadCurrentUserAsync()` to refresh the currently signed in user through `IFirebaseAuth`.
+
 ## Error handling
 
 Native Firebase Auth failures are wrapped in `CrossPlatformFirebaseAuthException`. The wrapper preserves the original native exception in `InnerException` and exposes stable inspection fields for the native exception type, domain, code, and message.
@@ -109,6 +114,8 @@ In v5:
 - `SignOutAsync()` now follows the same unified exception model when the underlying native Auth SDK reports a failure.
 
 ## Release notes
+- Next
+  - Add email/password user reauthentication and user-level reload APIs.
 - Version 5.0.1
   - Fix for wrong Core project version dependency at nuget.org
 - Version 5.0.0

--- a/src/Auth/Platforms/Android/FirebaseAuthImplementation.cs
+++ b/src/Auth/Platforms/Android/FirebaseAuthImplementation.cs
@@ -194,6 +194,7 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return FirebaseAuthExceptionFactory.Wrap(() => _firebaseAuth.SendPasswordResetEmailAsync(email));
     }
 
+    [Obsolete("Use CurrentUser.ReloadAsync() after checking CurrentUser is not null.")]
     public async Task ReloadCurrentUserAsync()
     {
         var currentUser = _firebaseAuth.CurrentUser;

--- a/src/Auth/Platforms/Android/FirebaseUserWrapper.cs
+++ b/src/Auth/Platforms/Android/FirebaseUserWrapper.cs
@@ -30,6 +30,17 @@ public sealed class FirebaseUserWrapper : IFirebaseUser
         return FirebaseAuthExceptionFactory.Wrap(() => _wrapped.UpdatePasswordAsync(password));
     }
 
+    public Task ReauthenticateWithEmailAndPasswordAsync(string email, string password)
+    {
+        var credential = EmailAuthProvider.GetCredential(email, password);
+        return FirebaseAuthExceptionFactory.Wrap(() => _wrapped.ReauthenticateAsync(credential));
+    }
+
+    public Task ReloadAsync()
+    {
+        return FirebaseAuthExceptionFactory.Wrap(() => _wrapped.ReloadAsync());
+    }
+
     public Task UpdatePhoneNumberAsync(string verificationId, string smsCode)
     {
         return FirebaseAuthExceptionFactory.Wrap(

--- a/src/Auth/Platforms/iOS/FirebaseAuthImplementation.cs
+++ b/src/Auth/Platforms/iOS/FirebaseAuthImplementation.cs
@@ -218,6 +218,7 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
     }
 
     /// <inheritdoc/>
+    [Obsolete("Use CurrentUser.ReloadAsync() after checking CurrentUser is not null.")]
     public async Task ReloadCurrentUserAsync()
     {
         var currentUser = _firebaseAuth.CurrentUser;

--- a/src/Auth/Platforms/iOS/FirebaseUserWrapper.cs
+++ b/src/Auth/Platforms/iOS/FirebaseUserWrapper.cs
@@ -38,6 +38,19 @@ public sealed class FirebaseUserWrapper : IFirebaseUser
     }
 
     /// <inheritdoc/>
+    public Task ReauthenticateWithEmailAndPasswordAsync(string email, string password)
+    {
+        var credential = EmailAuthProvider.GetCredentialFromPassword(email, password);
+        return FirebaseAuthExceptionFactory.Wrap(() => _wrapped.ReauthenticateAsync(credential));
+    }
+
+    /// <inheritdoc/>
+    public Task ReloadAsync()
+    {
+        return FirebaseAuthExceptionFactory.Wrap(() => _wrapped.ReloadAsync());
+    }
+
+    /// <inheritdoc/>
     public Task UpdatePhoneNumberAsync(string verificationId, string smsCode)
     {
         return FirebaseAuthExceptionFactory.Wrap(

--- a/src/Auth/Shared/IFirebaseAuth.cs
+++ b/src/Auth/Shared/IFirebaseAuth.cs
@@ -109,6 +109,7 @@ public interface IFirebaseAuth : IDisposable
     /// Reloads the currently signed in user from the backend.
     /// </summary>
     /// <exception cref="Plugin.Firebase.Core.Exceptions.FirebaseException">Thrown when no user is signed in.</exception>
+    [Obsolete("Use CurrentUser.ReloadAsync() after checking CurrentUser is not null.")]
     Task ReloadCurrentUserAsync();
 
     /// <summary>

--- a/src/Auth/Shared/IFirebaseUser.cs
+++ b/src/Auth/Shared/IFirebaseUser.cs
@@ -21,6 +21,18 @@ public interface IFirebaseUser
     Task UpdatePasswordAsync(string password);
 
     /// <summary>
+    /// Reauthenticates the user with an email address and password.
+    /// </summary>
+    /// <param name="email">The user’s email address.</param>
+    /// <param name="password">The user’s password.</param>
+    Task ReauthenticateWithEmailAndPasswordAsync(string email, string password);
+
+    /// <summary>
+    /// Reloads the user from the backend.
+    /// </summary>
+    Task ReloadAsync();
+
+    /// <summary>
     /// Updates the phone number for the user. On success, the cached user profile data is updated.
     /// </summary>
     /// <param name="verificationId">A valid verificationId retrieved by calling VerifyPhoneNumber().</param>

--- a/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
@@ -145,6 +145,43 @@ namespace Plugin.Firebase.IntegrationTests.Auth
         }
 
         [Fact]
+        public async Task reauthenticates_user_with_email_and_password()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var email = CreateUniqueEmail("reauth-email-password");
+            var user = await sut.SignInWithEmailAndPasswordAsync(email, "123456");
+            var uid = user.Uid;
+
+            await sut.CurrentUser.ReauthenticateWithEmailAndPasswordAsync(email, "123456");
+            await sut.CurrentUser.UpdatePasswordAsync("abcdefgh");
+
+            Assert.NotNull(sut.CurrentUser);
+            Assert.Equal(uid, sut.CurrentUser.Uid);
+
+            await sut.SignOutAsync();
+            await Assert.ThrowsAnyAsync<CrossPlatformFirebaseAuthException>(
+                () => sut.SignInWithEmailAndPasswordAsync(email, "123456", createsUserAutomatically: false)
+            );
+
+            var updatedUser = await sut.SignInWithEmailAndPasswordAsync(email, "abcdefgh", createsUserAutomatically: false);
+            Assert.Equal(uid, updatedUser.Uid);
+        }
+
+        [Fact]
+        public async Task throws_error_if_reauthenticating_with_invalid_email_password()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var email = CreateUniqueEmail("reauth-invalid");
+            await sut.SignInWithEmailAndPasswordAsync(email, "123456");
+
+            var ex = await Assert.ThrowsAnyAsync<CrossPlatformFirebaseAuthException>(
+                () => sut.CurrentUser.ReauthenticateWithEmailAndPasswordAsync(email, "000000")
+            );
+
+            AssertNativeAuthExceptionCaptured(ex);
+        }
+
+        [Fact]
         public async Task updates_user_profile()
         {
             const string displayName = "Bruce Wayne";
@@ -219,6 +256,21 @@ namespace Plugin.Firebase.IntegrationTests.Auth
 
             var uid = sut.CurrentUser.Uid;
             await sut.ReloadCurrentUserAsync();
+
+            Assert.NotNull(sut.CurrentUser);
+            Assert.Equal(uid, sut.CurrentUser.Uid);
+        }
+
+        [Fact]
+        public async Task reloads_user()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var email = CreateUniqueEmail("reload-user");
+            await sut.SignInWithEmailAndPasswordAsync(email, "123456");
+            Assert.NotNull(sut.CurrentUser);
+
+            var uid = sut.CurrentUser.Uid;
+            await sut.CurrentUser.ReloadAsync();
 
             Assert.NotNull(sut.CurrentUser);
             Assert.Equal(uid, sut.CurrentUser.Uid);

--- a/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
@@ -255,7 +255,9 @@ namespace Plugin.Firebase.IntegrationTests.Auth
             Assert.NotNull(sut.CurrentUser);
 
             var uid = sut.CurrentUser.Uid;
+#pragma warning disable CS0618
             await sut.ReloadCurrentUserAsync();
+#pragma warning restore CS0618
 
             Assert.NotNull(sut.CurrentUser);
             Assert.Equal(uid, sut.CurrentUser.Uid);

--- a/tests/Plugin.Firebase.UnitTests/Auth/UserProfileChangeRequestTests.cs
+++ b/tests/Plugin.Firebase.UnitTests/Auth/UserProfileChangeRequestTests.cs
@@ -91,6 +91,11 @@ public class UserProfileChangeRequestTests
 
         public Task UpdatePasswordAsync(string password) => Task.CompletedTask;
 
+        public Task ReauthenticateWithEmailAndPasswordAsync(string email, string password) =>
+            Task.CompletedTask;
+
+        public Task ReloadAsync() => Task.CompletedTask;
+
         public Task UpdatePhoneNumberAsync(string verificationId, string smsCode) => Task.CompletedTask;
 
 #pragma warning disable CS0618


### PR DESCRIPTION
## Summary
- Add email/password reauthentication to `IFirebaseUser`
- Add user-level `ReloadAsync()` alongside the existing auth-level reload API
- Cover reauth success, invalid reauth credentials, and user reload in integration tests
- Document the new Auth user APIs

## Why
Issue #425 asks for wrappers around Firebase Auth reauthentication and reload behavior needed before sensitive operations such as password changes and account deletion. Reload already exists on `IFirebaseAuth`; this adds the user-level gap and keeps the reauth surface intentionally scoped to email/password.

## Validation
- `dotnet format Plugin.Firebase.sln --verify-no-changes --include src/Auth/Shared/IFirebaseUser.cs src/Auth/Platforms/Android/FirebaseUserWrapper.cs src/Auth/Platforms/iOS/FirebaseUserWrapper.cs tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs`
- `dotnet build src/Auth/Auth.csproj -f net9.0 --no-restore`
- `dotnet build src/Auth/Auth.csproj -f net9.0-android --no-restore`
- `dotnet build src/Auth/Auth.csproj -f net9.0-ios --no-restore`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -f net9.0-android --no-restore`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -f net9.0-ios --no-restore -p:EnableCodeSigning=false`
- `git diff --check`

Note: the plain all-TFM integration build is blocked locally by missing iOS provisioning profiles; the iOS integration project compiles with code signing disabled.
