### PR TITLE
[codex] Add Firestore issue 522 regression test

### DIFF
--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs
@@ -1018,6 +1018,37 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         }
 
         [Fact]
+        public async Task updates_ios_transaction_dictionary_data_with_field_value_and_date_time_offset()
+        {
+            if(OperatingSystem.IsIOS() is false) {
+                return;
+            }
+
+            var sut = CrossFirebaseFirestore.Current;
+            var document = GetTestingDocument(sut, "ios-transaction-update-dictionary-field-value");
+            var seedDate = new DateTimeOffset(2025, 8, 27, 2, 9, 54, TimeSpan.Zero);
+            var expectedDate = new DateTimeOffset(2025, 8, 27, 3, 9, 54, TimeSpan.Zero);
+            await document.SetDataAsync(new Dictionary<object, object> {
+                { "array_values", new List<string> { "seed" } },
+                { "updated_at", seedDate }
+            });
+
+            await sut.RunTransactionAsync(transaction => {
+                transaction.GetDocument<Issue522TransactionUpdateDocument>(document);
+                transaction.UpdateData(document, new Dictionary<object, object> {
+                    { "array_values", FieldValue.ArrayUnion("added") },
+                    { "updated_at", expectedDate }
+                });
+                return true;
+            });
+
+            var result = (await document.GetDocumentSnapshotAsync<Issue522TransactionUpdateDocument>()).Data;
+            Assert.Contains("seed", result.ArrayValues);
+            Assert.Contains("added", result.ArrayValues);
+            Assert.Equal(expectedDate.ToUnixTimeMilliseconds(), result.UpdatedAt.ToUnixTimeMilliseconds());
+        }
+
+        [Fact]
         public async Task exposes_parent_relationships()
         {
             var sut = CrossFirebaseFirestore.Current;
@@ -1175,6 +1206,21 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
 
             [FirestoreProperty("values")]
             public Dictionary<string, Dictionary<string, short>> Values { get; private set; }
+        }
+
+        [Preserve(AllMembers = true)]
+        private sealed class Issue522TransactionUpdateDocument : IFirestoreObject
+        {
+            public Issue522TransactionUpdateDocument()
+            {
+                // needed for firestore
+            }
+
+            [FirestoreProperty("array_values")]
+            public IList<string> ArrayValues { get; private set; }
+
+            [FirestoreProperty("updated_at")]
+            public DateTimeOffset UpdatedAt { get; private set; }
         }
 
         [Preserve(AllMembers = true)]


### PR DESCRIPTION
## Summary

Adds targeted iOS integration coverage for GitHub issue #522.

The new test verifies that `TransactionWrapper.UpdateData(IDocumentReference, Dictionary<object, object>)` accepts a dictionary containing both a `FieldValue.ArrayUnion(...)` sentinel and a `DateTimeOffset` value.

## Root cause

Issue #522 reported that iOS transaction dictionary updates could pass plugin-level `FieldValue` values into the native Firebase binding without conversion, causing NSObject marshalling failures. Current development code now converts dictionary values before invoking the native transaction API; this test locks down the reported payload shape.

## Validation

- `git diff --check`
- `dotnet restore tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -p:TargetFramework=net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false --no-restore`