### PR TITLE
[codex] Add Firestore issue 482 regression coverage

### DIFF
--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreNullabilityFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreNullabilityFixture.cs
@@ -103,6 +103,34 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
         }
 
         [Fact]
+        public async Task updates_nested_object_dictionary_maps_from_document_batch_and_transaction_writes()
+        {
+            var sut = CrossFirebaseFirestore.Current;
+
+            var documentUpdate = GetTestingDocument(sut, "issue-482-document-update");
+            await documentUpdate.SetDataAsync(CreateNonNullItem("issue-482-document-update-seed"));
+            await documentUpdate.UpdateDataAsync(CreateIssue482NestedMapUpdate("document-update"));
+
+            var batchUpdate = GetTestingDocument(sut, "issue-482-batch-update");
+            await batchUpdate.SetDataAsync(CreateNonNullItem("issue-482-batch-update-seed"));
+
+            var batch = sut.CreateBatch();
+            batch.UpdateData(batchUpdate, CreateIssue482NestedMapUpdate("batch-update"));
+            await batch.CommitAsync();
+
+            var transactionUpdate = GetTestingDocument(sut, "issue-482-transaction-update");
+            await transactionUpdate.SetDataAsync(CreateNonNullItem("issue-482-transaction-update-seed"));
+            await sut.RunTransactionAsync(transaction => {
+                transaction.UpdateData(transactionUpdate, CreateIssue482NestedMapUpdate("transaction-update"));
+                return true;
+            });
+
+            await AssertIssue482NestedMapAsync(documentUpdate, "document-update");
+            await AssertIssue482NestedMapAsync(batchUpdate, "batch-update");
+            await AssertIssue482NestedMapAsync(transactionUpdate, "transaction-update");
+        }
+
+        [Fact]
         public async Task queries_documents_by_null_field_values()
         {
             var sut = CrossFirebaseFirestore.Current;
@@ -267,6 +295,19 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
             };
         }
 
+        private static Dictionary<object, object?> CreateIssue482NestedMapUpdate(string marker)
+        {
+            return new Dictionary<object, object?> {
+                {
+                    "nullable_map",
+                    new Dictionary<object, object?> {
+                        { "sub_field", $"{marker}-value" }
+                    }
+                },
+                { "query_marker", marker }
+            };
+        }
+
         private static Dictionary<object, object?> CreateNestedMap()
         {
             return new Dictionary<object, object?> {
@@ -295,6 +336,17 @@ namespace Plugin.Firebase.IntegrationTests.Firestore
 
             var list = Require(item.NullableList);
             Assert.Equal(["first", null, "last"], list);
+        }
+
+        private static async Task AssertIssue482NestedMapAsync(IDocumentReference document, string expectedMarker)
+        {
+            var snapshot = await document.GetDocumentSnapshotAsync<NullableFirestoreItem>(Source.Server);
+            var item = Require(snapshot.Data);
+            Assert.Equal(expectedMarker, item.QueryMarker);
+
+            var map = Require(item.NullableMap);
+            Assert.True(map.ContainsKey("sub_field"));
+            Assert.Equal($"{expectedMarker}-value", map["sub_field"]);
         }
 
         private static T Require<T>(T? value) where T : class


### PR DESCRIPTION
## Summary
- Add integration coverage for GitHub issue #482's nested `Dictionary<object, object?>` update payload.
- Cover `IDocumentReference.UpdateDataAsync`, `IWriteBatch.UpdateData`, and `ITransaction.UpdateData`.
- Reuse the existing nullable Firestore test model and helpers without changing public APIs.

## Validation
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-android -t:CoreCompile -maxcpucount:1 -nodeReuse:false`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false -maxcpucount:1 -nodeReuse:false`

Note: full Android packaging did not complete locally. The first full Android build hit MSBuild child-node socket failures, and a serial retry reached D8 packaging and stalled, so it was stopped after the integration test code had compiled.
