### PR TITLE
[codex] Fix Functions regional emulator initialization

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -15,6 +15,8 @@ Cloud Functions for Firebase is a serverless framework that lets you automatical
 - [Deploy](https://firebase.google.com/docs/functions/get-started?hl=en) your own function
 - Call `CrossFirebaseFunctions.Initialize(string region)` if your functions are deployed outside the default `us-central1` region
 
+Call `CrossFirebaseFunctions.Initialize(string region)` before accessing `CrossFirebaseFunctions.Current` or `CrossFirebaseFunctions.IsSupported`. If you change the region after `Current` has already been created, reacquire `CrossFirebaseFunctions.Current` before creating new callable references. Existing `IFirebaseFunctions` and `IHttpsCallable` references keep using the instance they were created from.
+
 ## Usage
 
 Take a look at the [documentation](https://firebase.google.com/docs/functions/callable?hl=en#call_the_function) for the official Firebase Cloud Function SKDs, because Plugin.Firebase's code is abstracted but still very similar.

--- a/src/Functions/Platforms/Android/FirebaseFunctionsImplementation.cs
+++ b/src/Functions/Platforms/Android/FirebaseFunctionsImplementation.cs
@@ -4,9 +4,13 @@ using Plugin.Firebase.Functions.Platforms.Android;
 
 namespace Plugin.Firebase.Functions;
 
-public sealed class FirebaseFunctionsImplementation : DisposableBase, IFirebaseFunctions
+public sealed class FirebaseFunctionsImplementation :
+    DisposableBase,
+    IFirebaseFunctions,
+    IFirebaseFunctionsEmulatorSettingsProvider
 {
     private readonly FirebaseFunctions _functions;
+    private FirebaseFunctionsEmulatorSettings? _emulatorSettings;
 
     public FirebaseFunctionsImplementation()
     {
@@ -26,5 +30,9 @@ public sealed class FirebaseFunctionsImplementation : DisposableBase, IFirebaseF
     public void UseEmulator(string host, int port)
     {
         _functions.UseEmulator(host, port);
+        _emulatorSettings = new FirebaseFunctionsEmulatorSettings(host, port);
     }
+
+    FirebaseFunctionsEmulatorSettings? IFirebaseFunctionsEmulatorSettingsProvider.EmulatorSettings =>
+        _emulatorSettings;
 }

--- a/src/Functions/Platforms/iOS/FirebaseFunctionsImplementation.cs
+++ b/src/Functions/Platforms/iOS/FirebaseFunctionsImplementation.cs
@@ -7,9 +7,13 @@ namespace Plugin.Firebase.Functions;
 /// <summary>
 /// iOS implementation of <see cref="IFirebaseFunctions"/> that wraps the native Firebase Cloud Functions SDK.
 /// </summary>
-public sealed class FirebaseFunctionsImplementation : DisposableBase, IFirebaseFunctions
+public sealed class FirebaseFunctionsImplementation :
+    DisposableBase,
+    IFirebaseFunctions,
+    IFirebaseFunctionsEmulatorSettingsProvider
 {
     private readonly CloudFunctions _functions;
+    private FirebaseFunctionsEmulatorSettings? _emulatorSettings;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FirebaseFunctionsImplementation"/> class using the default region.
@@ -38,5 +42,9 @@ public sealed class FirebaseFunctionsImplementation : DisposableBase, IFirebaseF
     public void UseEmulator(string host, int port)
     {
         _functions.UseEmulatorWithHost(host, port);
+        _emulatorSettings = new FirebaseFunctionsEmulatorSettings(host, port);
     }
+
+    FirebaseFunctionsEmulatorSettings? IFirebaseFunctionsEmulatorSettingsProvider.EmulatorSettings =>
+        _emulatorSettings;
 }

--- a/src/Functions/Shared/CrossFirebaseFunctions.cs
+++ b/src/Functions/Shared/CrossFirebaseFunctions.cs
@@ -5,11 +5,12 @@ namespace Plugin.Firebase.Functions;
 /// </summary>
 public sealed class CrossFirebaseFunctions
 {
+    private static readonly object SyncRoot = new();
     private static string _region;
-    private static Lazy<IFirebaseFunctions> _implementation = new Lazy<IFirebaseFunctions>(
-        CreateInstance,
-        LazyThreadSafetyMode.PublicationOnly
-    );
+    private static Lazy<IFirebaseFunctions> _implementation = CreateLazyImplementation();
+
+    private static Lazy<IFirebaseFunctions> CreateLazyImplementation() =>
+        new Lazy<IFirebaseFunctions>(CreateInstance, LazyThreadSafetyMode.PublicationOnly);
 
     private static IFirebaseFunctions CreateInstance()
     {
@@ -26,28 +27,51 @@ public sealed class CrossFirebaseFunctions
 
     /// <summary>
     /// Initialize Functions with a specific region.
+    /// Call this before using <see cref="Current"/>. If the region is changed after <see cref="Current"/>
+    /// was already created, reacquire <see cref="Current"/> before creating new callable references.
     /// </summary>
     /// <param name="region">e.g. 'us-central1'</param>
     public static void Initialize(string region)
     {
-        _region = region;
+        lock(SyncRoot) {
+            if(_region == region) {
+                return;
+            }
+
+            var emulatorSettings = GetCurrentEmulatorSettings();
+            var shouldRecreateImplementation = _implementation.IsValueCreated;
+
+            _region = region;
+
+            if(shouldRecreateImplementation) {
+                RecreateImplementation(emulatorSettings);
+            }
+        }
     }
 
     /// <summary>
     /// Gets if the plugin is supported on the current platform.
     /// </summary>
-    public static bool IsSupported => _implementation.Value != null;
+    public static bool IsSupported {
+        get {
+            lock(SyncRoot) {
+                return _implementation.Value != null;
+            }
+        }
+    }
 
     /// <summary>
     /// Current plugin implementation to use
     /// </summary>
     public static IFirebaseFunctions Current {
         get {
-            var ret = _implementation.Value;
-            if(ret == null) {
-                throw NotImplementedInReferenceAssembly();
+            lock(SyncRoot) {
+                var ret = _implementation.Value;
+                if(ret == null) {
+                    throw NotImplementedInReferenceAssembly();
+                }
+                return ret;
             }
-            return ret;
         }
     }
 
@@ -61,12 +85,40 @@ public sealed class CrossFirebaseFunctions
     /// </summary>
     public static void Dispose()
     {
-        if(_implementation != null && _implementation.IsValueCreated) {
-            _implementation.Value.Dispose();
-            _implementation = new Lazy<IFirebaseFunctions>(
-                CreateInstance,
-                LazyThreadSafetyMode.PublicationOnly
-            );
+        lock(SyncRoot) {
+            if(_implementation != null && _implementation.IsValueCreated) {
+                _implementation.Value?.Dispose();
+                _implementation = CreateLazyImplementation();
+            }
         }
     }
+
+    private static FirebaseFunctionsEmulatorSettings? GetCurrentEmulatorSettings()
+    {
+        if(!_implementation.IsValueCreated) {
+            return null;
+        }
+
+        return _implementation.Value is IFirebaseFunctionsEmulatorSettingsProvider emulatorSettingsProvider
+            ? emulatorSettingsProvider.EmulatorSettings
+            : null;
+    }
+
+    private static void RecreateImplementation(FirebaseFunctionsEmulatorSettings? emulatorSettings)
+    {
+        _implementation.Value?.Dispose();
+        _implementation = CreateLazyImplementation();
+
+        if(emulatorSettings.HasValue) {
+            var settings = emulatorSettings.Value;
+            _implementation.Value?.UseEmulator(settings.Host, settings.Port);
+        }
+    }
+}
+
+internal readonly record struct FirebaseFunctionsEmulatorSettings(string Host, int Port);
+
+internal interface IFirebaseFunctionsEmulatorSettingsProvider
+{
+    FirebaseFunctionsEmulatorSettings? EmulatorSettings { get; }
 }

--- a/tests/Plugin.Firebase.IntegrationTests/Functions/FunctionsFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Functions/FunctionsFixture.cs
@@ -1,4 +1,5 @@
 using Plugin.Firebase.Functions;
+using Xunit.Sdk;
 
 namespace Plugin.Firebase.IntegrationTests.Functions
 {
@@ -7,6 +8,10 @@ namespace Plugin.Firebase.IntegrationTests.Functions
     [Preserve(AllMembers = true)]
     public sealed class FunctionsFixture
     {
+        private const string RegionalFunctionsRegion = "southamerica-east1";
+        private const string RegionalPingFunctionName = "regionalPing";
+        private const long RegionalPingOutputValue = 541;
+
         [Fact]
         public async Task executes_simple_callable_function()
         {
@@ -38,6 +43,75 @@ namespace Plugin.Firebase.IntegrationTests.Functions
         {
             var sut = CrossFirebaseFunctions.Current;
             await Assert.ThrowsAnyAsync<Exception>(() => sut.GetHttpsCallable("doesNotExist").CallAsync());
+        }
+
+        [Fact]
+        public async Task uses_configured_region_when_initialize_runs_after_emulator_configuration()
+        {
+            SkipIfRealBackend();
+
+            try {
+                ResetFunctionsToDefaultRegion();
+                ConfigureFunctionsEmulator();
+
+                CrossFirebaseFunctions.Initialize(RegionalFunctionsRegion);
+
+                var response = await CrossFirebaseFunctions.Current
+                    .GetHttpsCallable(RegionalPingFunctionName)
+                    .CallAsync<SimpleResponseData>("{}");
+
+                Assert.Equal(RegionalPingOutputValue, response.OutputValue);
+            } finally {
+                RestoreDefaultFunctionsConfiguration();
+            }
+        }
+
+        [Fact]
+        public async Task uses_configured_region_after_is_supported_was_checked()
+        {
+            SkipIfRealBackend();
+
+            try {
+                ResetFunctionsToDefaultRegion();
+                Assert.True(CrossFirebaseFunctions.IsSupported);
+
+                CrossFirebaseFunctions.Initialize(RegionalFunctionsRegion);
+                ConfigureFunctionsEmulator();
+
+                var response = await CrossFirebaseFunctions.Current
+                    .GetHttpsCallable(RegionalPingFunctionName)
+                    .CallAsync<SimpleResponseData>("{}");
+
+                Assert.Equal(RegionalPingOutputValue, response.OutputValue);
+            } finally {
+                RestoreDefaultFunctionsConfiguration();
+            }
+        }
+
+        private static void SkipIfRealBackend()
+        {
+            if(IntegrationTestEnvironment.UsesRealBackend) {
+                throw SkipException.ForSkip(
+                    "This test uses the emulator-only regional function fixture.");
+            }
+        }
+
+        private static void RestoreDefaultFunctionsConfiguration()
+        {
+            ResetFunctionsToDefaultRegion();
+            ConfigureFunctionsEmulator();
+        }
+
+        private static void ResetFunctionsToDefaultRegion()
+        {
+            CrossFirebaseFunctions.Initialize(null);
+            CrossFirebaseFunctions.Dispose();
+        }
+
+        private static void ConfigureFunctionsEmulator()
+        {
+            var functions = IntegrationTestEnvironment.FunctionsEmulatorEndpoint;
+            CrossFirebaseFunctions.Current.UseEmulator(functions.Host, functions.Port);
         }
     }
 }

--- a/tests/cloud-functions/functions/src/index.ts
+++ b/tests/cloud-functions/functions/src/index.ts
@@ -22,6 +22,11 @@ exports.convertToLeet = functions.https.onCall(async (data, context) =>  {
   return `{ "input_value": ${data?.input_value}, "output_value": 1337 }`;
 });
 
+exports.regionalPing = functions.region('southamerica-east1').https.onCall(async () => {
+  functions.logger.log('[+] regionalPing');
+  return '{ "input_value": 0, "output_value": 541 }';
+});
+
 exports.echo = functions.https.onRequest(async (request, response) => {
     functions.logger.log(`[+] echo: headers = ${JSON.stringify(request.headers)}`);
     response.send(request.body);


### PR DESCRIPTION
## Summary
- Rebuild the cached Functions singleton when `CrossFirebaseFunctions.Initialize(region)` changes the configured region after early access.
- Preserve Functions emulator host/port settings across that rebuild on Android and iOS.
- Add emulator-backed regional callable coverage for the late-initialization scenarios from issue #541.
- Document the preferred initialization order and the need to reacquire `Current` after changing regions.

## Root cause
`CrossFirebaseFunctions.Current` is backed by a lazy static singleton. If `Current` or `IsSupported` was accessed before `Initialize(region)`, the default `us-central1` instance was created and later region initialization only updated `_region`, leaving the cached instance unchanged.

## Validation
- `dotnet build src/Functions/Functions.csproj -c Release -f net9.0`
- `dotnet build src/Functions/Functions.csproj -c Release -f net9.0-android` (passes with existing unrelated Core nullable warning)
- `dotnet build src/Functions/Functions.csproj -c Release -f net9.0-ios`
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj`
- `npm --prefix tests/cloud-functions/functions run build`
- iOS integration app build passed
- Android integration app build compiled the test assembly, but APK packaging hung locally in D8 and was stopped