### PR TITLE
[codex] Add profile update change request

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -70,6 +70,21 @@ Since code should be documenting itself you can also take a look at the followin
 - [tests/.../AuthFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs)
 - [sample/.../AuthService.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/sample/Playground/Common/Services/Auth/AuthService.cs)
 
+### Updating profile data
+
+Use `UserProfileChangeRequest.Builder` when updating profile fields. Fields omitted from the request remain unchanged, `null` clears a field, and `""` is passed through to Firebase as an explicit value.
+
+```csharp
+await CrossFirebaseAuth.Current.CurrentUser.UpdateProfileAsync(
+    new UserProfileChangeRequest.Builder()
+        .SetDisplayName("Bruce Wayne")
+        .SetPhotoUrl(null)
+        .Build()
+);
+```
+
+The legacy `UpdateProfileAsync(string? displayName = "", string? photoUrl = "")` overload treats `""` as omitted and is obsolete.
+
 ## Language
 
 Set `LanguageCode = "fr"` (or any BCP-47 code) before invoking an Auth flow that triggers user-facing content such as password-reset emails, email-verification emails, or phone-auth SMS.

--- a/src/Auth/Platforms/Android/FirebaseUserWrapper.cs
+++ b/src/Auth/Platforms/Android/FirebaseUserWrapper.cs
@@ -3,10 +3,12 @@ using Android.Runtime;
 using Firebase.Auth;
 using Plugin.Firebase.Auth.Platforms.Android.Extensions;
 using Uri = Android.Net.Uri;
+using NativeProfileChangeRequest = Firebase.Auth.UserProfileChangeRequest;
+using ProfileChangeRequest = Plugin.Firebase.Auth.UserProfileChangeRequest;
 
 namespace Plugin.Firebase.Auth.Platforms.Android;
 
-public sealed class FirebaseUserWrapper : IFirebaseUser
+public sealed class FirebaseUserWrapper : IFirebaseUser, IUserProfileChangeRequestHandler
 {
     private readonly FirebaseUser _wrapped;
 
@@ -37,18 +39,32 @@ public sealed class FirebaseUserWrapper : IFirebaseUser
         );
     }
 
-    public Task UpdateProfileAsync(string displayName = "", string photoUrl = "")
+    public Task UpdateProfileAsync(ProfileChangeRequest request)
     {
-        var builder = new UserProfileChangeRequest.Builder();
+        var builder = new NativeProfileChangeRequest.Builder();
+        if(request.UpdatesDisplayName) {
+            builder.SetDisplayName(request.DisplayName);
+        }
+        if(request.UpdatesPhotoUrl) {
+            builder.SetPhotoUri(request.PhotoUrl == null ? null : Uri.Parse(request.PhotoUrl));
+        }
+
+        var nativeRequest = builder.Build();
+        return FirebaseAuthExceptionFactory.Wrap(() => _wrapped.UpdateProfileAsync(nativeRequest));
+    }
+
+    [Obsolete("Use UpdateProfileAsync(UserProfileChangeRequest request) to distinguish omitted, null, and empty string values.")]
+    public Task UpdateProfileAsync(string? displayName = "", string? photoUrl = "")
+    {
+        var builder = new ProfileChangeRequest.Builder();
         if(displayName != "") {
             builder.SetDisplayName(displayName);
         }
         if(photoUrl != "") {
-            builder.SetPhotoUri(string.IsNullOrEmpty(photoUrl) ? null : Uri.Parse(photoUrl));
+            builder.SetPhotoUrl(photoUrl);
         }
 
-        var request = builder.Build();
-        return FirebaseAuthExceptionFactory.Wrap(() => _wrapped.UpdateProfileAsync(request));
+        return UpdateProfileAsync(builder.Build());
     }
 
     public Task SendEmailVerificationAsync(ActionCodeSettings? actionCodeSettings = null)

--- a/src/Auth/Platforms/iOS/FirebaseUserWrapper.cs
+++ b/src/Auth/Platforms/iOS/FirebaseUserWrapper.cs
@@ -1,12 +1,13 @@
 using Firebase.Auth;
 using Plugin.Firebase.Auth.Platforms.iOS.Extensions;
+using ProfileChangeRequest = Plugin.Firebase.Auth.UserProfileChangeRequest;
 
 namespace Plugin.Firebase.Auth.Platforms.iOS;
 
 /// <summary>
 /// Wraps a native iOS Firebase User for cross-platform access.
 /// </summary>
-public sealed class FirebaseUserWrapper : IFirebaseUser
+public sealed class FirebaseUserWrapper : IFirebaseUser, IUserProfileChangeRequestHandler
 {
     private readonly User _wrapped;
 
@@ -48,17 +49,32 @@ public sealed class FirebaseUserWrapper : IFirebaseUser
     }
 
     /// <inheritdoc/>
-    public Task UpdateProfileAsync(string displayName = "", string photoUrl = "")
+    public Task UpdateProfileAsync(ProfileChangeRequest request)
     {
-        var request = _wrapped.ProfileChangeRequest();
-        if(displayName != "") {
-            request.DisplayName = displayName;
+        var nativeRequest = _wrapped.ProfileChangeRequest();
+        if(request.UpdatesDisplayName) {
+            nativeRequest.DisplayName = request.DisplayName;
         }
-        if(photoUrl != "") {
-            request.PhotoUrl = photoUrl == null ? null : new NSUrl(photoUrl);
+        if(request.UpdatesPhotoUrl) {
+            nativeRequest.PhotoUrl = request.PhotoUrl == null ? null : new NSUrl(request.PhotoUrl);
         }
 
-        return FirebaseAuthExceptionFactory.Wrap(() => request.CommitChangesAsync());
+        return FirebaseAuthExceptionFactory.Wrap(() => nativeRequest.CommitChangesAsync());
+    }
+
+    /// <inheritdoc/>
+    [Obsolete("Use UpdateProfileAsync(UserProfileChangeRequest request) to distinguish omitted, null, and empty string values.")]
+    public Task UpdateProfileAsync(string? displayName = "", string? photoUrl = "")
+    {
+        var builder = new ProfileChangeRequest.Builder();
+        if(displayName != "") {
+            builder.SetDisplayName(displayName);
+        }
+        if(photoUrl != "") {
+            builder.SetPhotoUrl(photoUrl);
+        }
+
+        return UpdateProfileAsync(builder.Build());
     }
 
     /// <inheritdoc/>

--- a/src/Auth/Shared/FirebaseUserExtensions.cs
+++ b/src/Auth/Shared/FirebaseUserExtensions.cs
@@ -1,0 +1,54 @@
+namespace Plugin.Firebase.Auth;
+
+/// <summary>
+/// Extension methods for <see cref="IFirebaseUser"/>.
+/// </summary>
+public static class FirebaseUserExtensions
+{
+    /// <summary>
+    /// Changes the user's profile data.
+    /// </summary>
+    /// <param name="firebaseUser">The user to update.</param>
+    /// <param name="request">The requested profile changes. Omitted fields remain unchanged.</param>
+    public static Task UpdateProfileAsync(
+        this IFirebaseUser firebaseUser,
+        UserProfileChangeRequest request
+    )
+    {
+        ArgumentNullException.ThrowIfNull(firebaseUser);
+
+        if(firebaseUser is IUserProfileChangeRequestHandler handler) {
+            return handler.UpdateProfileAsync(request);
+        }
+
+        if(
+            (request.UpdatesDisplayName && request.DisplayName == "")
+            || (request.UpdatesPhotoUrl && request.PhotoUrl == "")
+        ) {
+            throw new NotSupportedException(
+                $"{nameof(UserProfileChangeRequest)} empty string values require an {nameof(IFirebaseUser)} implementation that supports the request-based profile update API."
+            );
+        }
+
+#pragma warning disable CS0618
+        if(request.UpdatesDisplayName && request.UpdatesPhotoUrl) {
+            return firebaseUser.UpdateProfileAsync(request.DisplayName, request.PhotoUrl);
+        }
+
+        if(request.UpdatesDisplayName) {
+            return firebaseUser.UpdateProfileAsync(displayName: request.DisplayName);
+        }
+
+        if(request.UpdatesPhotoUrl) {
+            return firebaseUser.UpdateProfileAsync(photoUrl: request.PhotoUrl);
+        }
+
+        return firebaseUser.UpdateProfileAsync();
+#pragma warning restore CS0618
+    }
+}
+
+internal interface IUserProfileChangeRequestHandler
+{
+    Task UpdateProfileAsync(UserProfileChangeRequest request);
+}

--- a/src/Auth/Shared/IFirebaseUser.cs
+++ b/src/Auth/Shared/IFirebaseUser.cs
@@ -28,11 +28,16 @@ public interface IFirebaseUser
     Task UpdatePhoneNumberAsync(string verificationId, string smsCode);
 
     /// <summary>
-    /// Change the user’s profile data.
+    /// Changes the user's profile data.
     /// </summary>
-    /// <param name="displayName">The user’s display name.</param>
-    /// <param name="photoUrl">The user’s photo URL.</param>
-    Task UpdateProfileAsync(string displayName = "", string photoUrl = "");
+    /// <remarks>
+    /// This legacy overload treats <c>""</c> as omitted. Use the <see cref="UserProfileChangeRequest"/>
+    /// to pass <c>""</c> through as a value.
+    /// </remarks>
+    /// <param name="displayName">The user's display name.</param>
+    /// <param name="photoUrl">The user's photo URL.</param>
+    [Obsolete("Use UpdateProfileAsync(UserProfileChangeRequest request) to distinguish omitted, null, and empty string values.")]
+    Task UpdateProfileAsync(string? displayName = "", string? photoUrl = "");
 
     /// <summary>
     /// Initiates email verification for the user.

--- a/src/Auth/Shared/UserProfileChangeRequest.cs
+++ b/src/Auth/Shared/UserProfileChangeRequest.cs
@@ -1,0 +1,86 @@
+namespace Plugin.Firebase.Auth;
+
+/// <summary>
+/// A request object for changing Firebase user profile fields.
+/// </summary>
+public readonly struct UserProfileChangeRequest
+{
+    private UserProfileChangeRequest(
+        string? displayName,
+        bool updatesDisplayName,
+        string? photoUrl,
+        bool updatesPhotoUrl
+    )
+    {
+        DisplayName = displayName;
+        UpdatesDisplayName = updatesDisplayName;
+        PhotoUrl = photoUrl;
+        UpdatesPhotoUrl = updatesPhotoUrl;
+    }
+
+    /// <summary>
+    /// Gets the display name to set when <see cref="UpdatesDisplayName"/> is <c>true</c>.
+    /// </summary>
+    public string? DisplayName { get; }
+
+    /// <summary>
+    /// Gets whether the display name should be changed.
+    /// </summary>
+    public bool UpdatesDisplayName { get; }
+
+    /// <summary>
+    /// Gets the photo URL to set when <see cref="UpdatesPhotoUrl"/> is <c>true</c>.
+    /// </summary>
+    public string? PhotoUrl { get; }
+
+    /// <summary>
+    /// Gets whether the photo URL should be changed.
+    /// </summary>
+    public bool UpdatesPhotoUrl { get; }
+
+    /// <summary>
+    /// Builds <see cref="UserProfileChangeRequest"/> instances.
+    /// </summary>
+    public sealed class Builder
+    {
+        private string? _displayName;
+        private string? _photoUrl;
+        private bool _updatesDisplayName;
+        private bool _updatesPhotoUrl;
+
+        /// <summary>
+        /// Sets the user's display name. Pass <c>null</c> to clear it.
+        /// </summary>
+        /// <param name="displayName">The display name to set.</param>
+        public Builder SetDisplayName(string? displayName)
+        {
+            _displayName = displayName;
+            _updatesDisplayName = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the user's photo URL. Pass <c>null</c> to clear it.
+        /// </summary>
+        /// <param name="photoUrl">The photo URL to set.</param>
+        public Builder SetPhotoUrl(string? photoUrl)
+        {
+            _photoUrl = photoUrl;
+            _updatesPhotoUrl = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Builds a request with the values set on this builder.
+        /// </summary>
+        public UserProfileChangeRequest Build()
+        {
+            return new UserProfileChangeRequest(
+                _displayName,
+                _updatesDisplayName,
+                _photoUrl,
+                _updatesPhotoUrl
+            );
+        }
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
@@ -150,34 +150,81 @@ namespace Plugin.Firebase.IntegrationTests.Auth
             const string displayName = "Bruce Wayne";
             const string photoUrl = "https://url.to/image.jpg";
             var sut = CrossFirebaseAuth.Current;
-            await sut.SignInWithEmailAndPasswordAsync("to-update-profile@test.com", "123456");
+            await sut.SignInWithEmailAndPasswordAsync(CreateUniqueEmail("update-profile"), "123456");
             Assert.NotNull(sut.CurrentUser);
             Assert.Null(sut.CurrentUser.DisplayName);
             Assert.Null(sut.CurrentUser.PhotoUrl);
 
-            await sut.CurrentUser.UpdateProfileAsync(displayName, photoUrl);
+            await sut.CurrentUser.UpdateProfileAsync(
+                new UserProfileChangeRequest.Builder()
+                    .SetDisplayName(displayName)
+                    .SetPhotoUrl(photoUrl)
+                    .Build()
+            );
             Assert.Equal(displayName, sut.CurrentUser.DisplayName);
             Assert.Equal(photoUrl, sut.CurrentUser.PhotoUrl);
 
-            await sut.CurrentUser.UpdateProfileAsync(displayName: null);
+            await sut.CurrentUser.UpdateProfileAsync(
+                new UserProfileChangeRequest.Builder()
+                    .SetDisplayName(null)
+                    .Build()
+            );
             Assert.Null(sut.CurrentUser.DisplayName);
             Assert.Equal(photoUrl, sut.CurrentUser.PhotoUrl);
 
-            await sut.CurrentUser.UpdateProfileAsync(displayName);
+            await sut.CurrentUser.UpdateProfileAsync(
+                new UserProfileChangeRequest.Builder()
+                    .SetDisplayName(displayName)
+                    .Build()
+            );
             Assert.Equal(displayName, sut.CurrentUser.DisplayName);
             Assert.Equal(photoUrl, sut.CurrentUser.PhotoUrl);
 
-            await sut.CurrentUser.UpdateProfileAsync(photoUrl: null);
+            await sut.CurrentUser.UpdateProfileAsync(
+                new UserProfileChangeRequest.Builder()
+                    .SetPhotoUrl(null)
+                    .Build()
+            );
             Assert.Equal(displayName, sut.CurrentUser.DisplayName);
             Assert.Null(sut.CurrentUser.PhotoUrl);
 
-            await sut.CurrentUser.UpdateProfileAsync(photoUrl: photoUrl);
+            await sut.CurrentUser.UpdateProfileAsync(
+                new UserProfileChangeRequest.Builder()
+                    .SetPhotoUrl(photoUrl)
+                    .Build()
+            );
             Assert.Equal(displayName, sut.CurrentUser.DisplayName);
             Assert.Equal(photoUrl, sut.CurrentUser.PhotoUrl);
 
+            await sut.CurrentUser.UpdateProfileAsync(
+                new UserProfileChangeRequest.Builder()
+                    .SetDisplayName("")
+                    .Build()
+            );
+            Assert.Equal("", sut.CurrentUser.DisplayName);
+            Assert.Equal(photoUrl, sut.CurrentUser.PhotoUrl);
+        }
+
+        [Fact]
+        public async Task legacy_update_user_profile_overload_treats_empty_string_as_omitted()
+        {
+            const string displayName = "Bruce Wayne";
+            const string photoUrl = "https://url.to/image.jpg";
+            var sut = CrossFirebaseAuth.Current;
+            await sut.SignInWithEmailAndPasswordAsync(CreateUniqueEmail("legacy-update-profile"), "123456");
+            Assert.NotNull(sut.CurrentUser);
+
+#pragma warning disable CS0618
             await sut.CurrentUser.UpdateProfileAsync(displayName, photoUrl);
+            await sut.CurrentUser.UpdateProfileAsync(displayName: "");
+            await sut.CurrentUser.UpdateProfileAsync(photoUrl: "");
             Assert.Equal(displayName, sut.CurrentUser.DisplayName);
             Assert.Equal(photoUrl, sut.CurrentUser.PhotoUrl);
+
+            await sut.CurrentUser.UpdateProfileAsync(null);
+            Assert.Null(sut.CurrentUser.DisplayName);
+            Assert.Equal(photoUrl, sut.CurrentUser.PhotoUrl);
+#pragma warning restore CS0618
         }
 
         [Fact]

--- a/tests/Plugin.Firebase.UnitTests/Auth/UserProfileChangeRequestTests.cs
+++ b/tests/Plugin.Firebase.UnitTests/Auth/UserProfileChangeRequestTests.cs
@@ -1,0 +1,125 @@
+using Plugin.Firebase.Auth;
+
+namespace Plugin.Firebase.UnitTests.Auth;
+
+public class UserProfileChangeRequestTests
+{
+    [Fact]
+    public void build_without_values_marks_no_fields_for_update()
+    {
+        var sut = new UserProfileChangeRequest.Builder().Build();
+
+        Assert.False(sut.UpdatesDisplayName);
+        Assert.Null(sut.DisplayName);
+        Assert.False(sut.UpdatesPhotoUrl);
+        Assert.Null(sut.PhotoUrl);
+    }
+
+    [Fact]
+    public void set_display_name_tracks_null_value()
+    {
+        var sut = new UserProfileChangeRequest.Builder()
+            .SetDisplayName(null)
+            .Build();
+
+        Assert.True(sut.UpdatesDisplayName);
+        Assert.Null(sut.DisplayName);
+        Assert.False(sut.UpdatesPhotoUrl);
+    }
+
+    [Fact]
+    public void set_photo_url_tracks_empty_string_value()
+    {
+        var sut = new UserProfileChangeRequest.Builder()
+            .SetPhotoUrl("")
+            .Build();
+
+        Assert.False(sut.UpdatesDisplayName);
+        Assert.True(sut.UpdatesPhotoUrl);
+        Assert.Equal("", sut.PhotoUrl);
+    }
+
+    [Fact]
+    public void build_captures_current_builder_values()
+    {
+        var builder = new UserProfileChangeRequest.Builder()
+            .SetDisplayName("Ada")
+            .SetPhotoUrl("https://url.to/ada.jpg");
+
+        var sut = builder.Build();
+        builder.SetDisplayName("Grace").SetPhotoUrl(null);
+
+        Assert.True(sut.UpdatesDisplayName);
+        Assert.Equal("Ada", sut.DisplayName);
+        Assert.True(sut.UpdatesPhotoUrl);
+        Assert.Equal("https://url.to/ada.jpg", sut.PhotoUrl);
+    }
+
+    [Fact]
+    public async Task extension_delegates_to_legacy_overload_for_existing_implementations()
+    {
+        IFirebaseUser sut = new LegacyFirebaseUser();
+        var request = new UserProfileChangeRequest.Builder()
+            .SetDisplayName(null)
+            .SetPhotoUrl("https://url.to/ada.jpg")
+            .Build();
+
+        await sut.UpdateProfileAsync(request);
+
+        var legacyUser = Assert.IsType<LegacyFirebaseUser>(sut);
+        Assert.Null(legacyUser.DisplayNameArgument);
+        Assert.Equal("https://url.to/ada.jpg", legacyUser.PhotoUrlArgument);
+    }
+
+    [Fact]
+    public async Task extension_rejects_empty_strings_for_existing_implementations()
+    {
+        IFirebaseUser sut = new LegacyFirebaseUser();
+        var request = new UserProfileChangeRequest.Builder()
+            .SetDisplayName("")
+            .Build();
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => sut.UpdateProfileAsync(request));
+    }
+
+    private sealed class LegacyFirebaseUser : IFirebaseUser
+    {
+        public string? DisplayNameArgument { get; private set; }
+        public string? PhotoUrlArgument { get; private set; }
+
+        public Task UpdateEmailAsync(string email) => Task.CompletedTask;
+
+        public Task UpdatePasswordAsync(string password) => Task.CompletedTask;
+
+        public Task UpdatePhoneNumberAsync(string verificationId, string smsCode) => Task.CompletedTask;
+
+#pragma warning disable CS0618
+        public Task UpdateProfileAsync(string? displayName = "", string? photoUrl = "")
+#pragma warning restore CS0618
+        {
+            DisplayNameArgument = displayName;
+            PhotoUrlArgument = photoUrl;
+            return Task.CompletedTask;
+        }
+
+        public Task SendEmailVerificationAsync(ActionCodeSettings? actionCodeSettings = null) =>
+            Task.CompletedTask;
+
+        public Task UnlinkAsync(string providerId) => Task.CompletedTask;
+
+        public Task DeleteAsync() => Task.CompletedTask;
+
+        public Task<IAuthTokenResult> GetIdTokenResultAsync(bool forceRefresh = false) =>
+            throw new NotImplementedException();
+
+        public string Uid => "uid";
+        public string? DisplayName => null;
+        public string? Email => null;
+        public string? PhotoUrl => null;
+        public string ProviderId => "firebase";
+        public bool IsEmailVerified => false;
+        public bool IsAnonymous => false;
+        public IEnumerable<ProviderInfo>? ProviderInfos => null;
+        public UserMetadata? Metadata => null;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a request-based Auth profile update API for issue #594 so callers can distinguish omitted profile fields, explicit `null` clears, and explicit empty string values.

## Changes

- Adds `UserProfileChangeRequest` with a builder for display name and photo URL updates.
- Adds an `IFirebaseUser` extension method that uses request-aware platform implementations when available while preserving compatibility for existing interface implementers.
- Marks the legacy string overload obsolete and keeps its existing empty-string-as-omitted behavior.
- Updates Android and iOS wrappers, Auth docs, integration coverage, and unit tests.

## Root Cause

The old `UpdateProfileAsync(string displayName = "", string photoUrl = "")` overload used `""` as the omitted-field sentinel, so callers could not intentionally set a profile field to an empty string while also preserving clear-via-`null` semantics.

## Validation

- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj`
- `dotnet build src/Auth/Auth.csproj -c Release -f net9.0-ios`
- `dotnet build src/Auth/Auth.csproj -c Release -f net9.0-android`
- `dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Release -f net9.0-android`