### PR TITLE
[codex] Fix Crashlytics Android binding compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Validate CloudMessaging trimming
         run: scripts/validate-cloudmessaging-trimming.sh
 
+      - name: Validate Crashlytics compatibility
+        run: scripts/validate-crashlytics-compatibility.sh
+
       - name: Run unit tests
         run: |
           dotnet restore tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ When selecting package versions for iOS, best practice is to make sure that the 
 
 When selecting package versions for Android, best practice is to [choose a Firebase BoM](https://firebase.google.com/support/release-notes/android) and select matching package versions for each dependency. As examples, if you wish to use BoM version 33.8.0, then you would want to select Xamarin.Firebase.Analytics v122.2.0 and Xamarin.Firebase.Auth v123.1.0.
 
+Plugin.Firebase 4.x defaults to Firebase BoM 33.0 as its minimum Android Firebase SDK line. Newer BoM lines, such as BoM 34.x / Crashlytics 20.x, should be adopted intentionally across the full Android Firebase dependency set rather than by upgrading one `Xamarin.Firebase.*` package in isolation.
+
 - Xamarin.Firebase.Analytics
 - Xamarin.Firebase.Auth
 - Xamarin.Firebase.AppCheck

--- a/docs/crashlytics.md
+++ b/docs/crashlytics.md
@@ -59,6 +59,9 @@ The exported symbols file must be plain UTF-8 without a byte order mark or other
 </ItemGroup>
 ```
 - After adding or changing Android resources, clean `bin` and `obj` and rebuild the app if Crashlytics still reports a missing build ID.
+- Plugin.Firebase's default Android Firebase baseline is Firebase BoM 33.0 / `Xamarin.Firebase.Crashlytics` 119.0.0. If you explicitly manage Android Firebase package versions, choose a coherent Firebase BoM and align all `Xamarin.Firebase.*` package versions to that BoM.
+- `Xamarin.Firebase.Crashlytics` 119.1.0 and later changed the .NET binding shape for `SetCrashlyticsCollectionEnabled` to prefer `Java.Lang.Boolean`. Plugin.Firebase versions containing the Android binding compatibility fix compile against tested Crashlytics 19.x packages up to 119.4.4.
+- Crashlytics 20.x maps to the Firebase BoM 34.x dependency line. Plugin.Firebase versions containing the Android binding compatibility fix are compile-compatible in targeted validation against tested Crashlytics 20.x packages up to 120.0.5, but BoM 34.x should be treated as an intentional full Firebase Android dependency upgrade rather than Plugin.Firebase's default baseline.
 - For more specific instructions take a look at the official [Firebase documentation](https://firebase.google.com/docs/crashlytics/get-started?platform=android)
 
 ## Usage

--- a/scripts/validate-crashlytics-compatibility.sh
+++ b/scripts/validate-crashlytics-compatibility.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+versions=(
+  "119.0.0"
+  "119.0.3.2"
+  "119.1.0"
+  "119.4.4"
+  "120.0.0"
+  "120.0.5"
+)
+projects=(
+  "$repo_root/src/Crashlytics/Crashlytics.csproj"
+  "$repo_root/src/Bundled/Bundled.csproj"
+)
+
+for version in "${versions[@]}"; do
+  datastore_version="1.1.1.8"
+  case "$version" in
+    119.4.4|120.0.0)
+      datastore_version="1.1.7"
+      ;;
+    120.0.5)
+      datastore_version="1.2.1"
+      ;;
+  esac
+
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::group::Validate Xamarin.Firebase.Crashlytics $version with Xamarin.AndroidX.DataStore $datastore_version"
+  else
+    echo "Validating Xamarin.Firebase.Crashlytics $version with Xamarin.AndroidX.DataStore $datastore_version"
+  fi
+
+  for project in "${projects[@]}"; do
+    dotnet build "$project" \
+      -c Release \
+      -f net9.0-android \
+      -m:1 \
+      --disable-build-servers \
+      -p:UseSharedCompilation=false \
+      -p:XamarinFirebaseCrashlyticsVersion="$version" \
+      -p:XamarinAndroidXDataStoreVersion="$datastore_version"
+  done
+
+  dotnet build-server shutdown >/dev/null 2>&1 || true
+
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::endgroup::"
+  fi
+done
+
+echo "Validated Crashlytics Android compatibility for ${#versions[@]} package versions."

--- a/src/Bundled/Platforms/Android/CrossFirebase.cs
+++ b/src/Bundled/Platforms/Android/CrossFirebase.cs
@@ -56,7 +56,9 @@ public static class CrossFirebase
             FirebaseAnalyticsImplementation.Initialize(activity);
         }
 
-        FirebaseCrashlytics.Instance.SetCrashlyticsCollectionEnabled(settings.IsCrashlyticsEnabled);
+        FirebaseCrashlytics.Instance.SetCrashlyticsCollectionEnabled(
+            Java.Lang.Boolean.ValueOf(settings.IsCrashlyticsEnabled)
+        );
 
         Console.WriteLine($"Plugin.Firebase initialized with the following settings:\n{settings}");
     }

--- a/src/Crashlytics/Crashlytics.csproj
+++ b/src/Crashlytics/Crashlytics.csproj
@@ -41,6 +41,8 @@
 
         <!--Version of C# to use -->
         <LangVersion>default</LangVersion>
+        <XamarinFirebaseCrashlyticsVersion Condition="'$(XamarinFirebaseCrashlyticsVersion)' == ''">119.0.0</XamarinFirebaseCrashlyticsVersion>
+        <XamarinAndroidXDataStoreVersion Condition="'$(XamarinAndroidXDataStoreVersion)' == ''">1.1.1.8</XamarinAndroidXDataStoreVersion>
     </PropertyGroup>
     
     <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
@@ -85,8 +87,8 @@
 
     <!-- nuget packages -->
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-        <PackageReference Include="Xamarin.AndroidX.DataStore" Version="1.1.1.8" />
-        <PackageReference Include="Xamarin.Firebase.Crashlytics" Version="119.0.0" />
+        <PackageReference Include="Xamarin.AndroidX.DataStore" Version="$(XamarinAndroidXDataStoreVersion)" />
+        <PackageReference Include="Xamarin.Firebase.Crashlytics" Version="$(XamarinFirebaseCrashlyticsVersion)" />
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">

--- a/src/Crashlytics/Platforms/Android/FirebaseCrashlyticsImplementation.cs
+++ b/src/Crashlytics/Platforms/Android/FirebaseCrashlyticsImplementation.cs
@@ -16,7 +16,7 @@ public sealed class FirebaseCrashlyticsImplementation : DisposableBase, IFirebas
 
     public void SetCrashlyticsCollectionEnabled(bool enabled)
     {
-        _instance.SetCrashlyticsCollectionEnabled(enabled);
+        _instance.SetCrashlyticsCollectionEnabled(Java.Lang.Boolean.ValueOf(enabled));
     }
 
     public void SetCustomKey(string key, bool value)


### PR DESCRIPTION
## Summary
- Fix Android Crashlytics collection-enabled calls by passing `Java.Lang.Boolean` into the native binding.
- Keep Plugin.Firebase's default Android Firebase baseline at BoM 33.0 / `Xamarin.Firebase.Crashlytics` 119.0.0.
- Add a CI compatibility matrix for tested Crashlytics 19.x and 20.x package lines.
- Document the BoM 33.0 default and the intentional-upgrade guidance for BoM 34.x / Crashlytics 20.x.

## Root cause
`Xamarin.Firebase.Crashlytics` 119.1.0 and later changed the .NET binding shape for `SetCrashlyticsCollectionEnabled` to prefer `Java.Lang.Boolean`, while Plugin.Firebase was compiled against the earlier `bool` binding call. Consumers overriding to newer Crashlytics packages could hit binding incompatibility.

## Validation
- `scripts/validate-crashlytics-compatibility.sh` passed for 119.0.0, 119.0.3.2, 119.1.0, 119.4.4, 120.0.0, and 120.0.5.
- `120.0.5` emitted expected NU1608 DataStore warnings but completed with 0 errors.
- `dotnet build src/Crashlytics/Crashlytics.csproj -c Release -f net9.0-android` passed.
- `dotnet build src/Bundled/Bundled.csproj -c Release -f net9.0-android` passed.
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj -c Release -f net9.0` passed: 53/53.
