### PR TITLE
[codex] Expose native auth credential APIs

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -70,6 +70,24 @@ Since code should be documenting itself you can also take a look at the followin
 - [tests/.../AuthFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs)
 - [sample/.../AuthService.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/sample/Playground/Common/Services/Auth/AuthService.cs)
 
+### Native provider credentials
+
+Provider SDKs create native Firebase credentials in platform-specific code. After you create a native `Firebase.Auth.AuthCredential`, pass it through the cross-platform Auth entry point to keep exception handling and user conversion consistent:
+
+```csharp
+using Plugin.Firebase.Auth;
+
+#if ANDROID
+var credential = Firebase.Auth.EmailAuthProvider.GetCredential(email, password);
+#elif IOS
+var credential = Firebase.Auth.EmailAuthProvider.GetCredentialFromPassword(email, password);
+#endif
+
+var user = await CrossFirebaseAuth.Current.SignInWithCredentialAsync(credential);
+```
+
+Use `LinkWithCredentialAsync(credential)` the same way when linking a provider credential to the current user.
+
 ## Language
 
 Set `LanguageCode = "fr"` (or any BCP-47 code) before invoking an Auth flow that triggers user-facing content such as password-reset emails, email-verification emails, or phone-auth SMS.

--- a/src/Auth/Platforms/Android/FirebaseAuthImplementation.cs
+++ b/src/Auth/Platforms/Android/FirebaseAuthImplementation.cs
@@ -57,7 +57,7 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return await SignInWithCredentialAsync(credential);
     }
 
-    private async Task<IFirebaseUser> SignInWithCredentialAsync(AuthCredential credential)
+    public async Task<IFirebaseUser> SignInWithCredentialAsync(AuthCredential credential)
     {
         var authResult = await FirebaseAuthExceptionFactory.Wrap(
             () => _firebaseAuth.SignInWithCredentialAsync(credential)
@@ -121,7 +121,7 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return await LinkWithCredentialAsync(credential);
     }
 
-    private async Task<IFirebaseUser> LinkWithCredentialAsync(AuthCredential credential)
+    public async Task<IFirebaseUser> LinkWithCredentialAsync(AuthCredential credential)
     {
         var currentUser = _firebaseAuth.CurrentUser;
         if(currentUser is null) {

--- a/src/Auth/Platforms/Android/FirebaseAuthImplementation.cs
+++ b/src/Auth/Platforms/Android/FirebaseAuthImplementation.cs
@@ -57,6 +57,7 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return await SignInWithCredentialAsync(credential);
     }
 
+    /// <inheritdoc/>
     public async Task<IFirebaseUser> SignInWithCredentialAsync(AuthCredential credential)
     {
         var authResult = await FirebaseAuthExceptionFactory.Wrap(
@@ -121,6 +122,7 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return await LinkWithCredentialAsync(credential);
     }
 
+    /// <inheritdoc/>
     public async Task<IFirebaseUser> LinkWithCredentialAsync(AuthCredential credential)
     {
         var currentUser = _firebaseAuth.CurrentUser;

--- a/src/Auth/Platforms/Android/IFirebaseAuth.cs
+++ b/src/Auth/Platforms/Android/IFirebaseAuth.cs
@@ -1,0 +1,20 @@
+using Firebase.Auth;
+
+namespace Plugin.Firebase.Auth;
+
+public partial interface IFirebaseAuth
+{
+    /// <summary>
+    /// Signs in using a native Firebase Auth credential.
+    /// </summary>
+    /// <param name="credential">The native Android Firebase Auth credential.</param>
+    /// <returns>The signed in <c>IFirebaseUser</c> object.</returns>
+    Task<IFirebaseUser> SignInWithCredentialAsync(AuthCredential credential);
+
+    /// <summary>
+    /// Links the signed in user with a native Firebase Auth credential.
+    /// </summary>
+    /// <param name="credential">The native Android Firebase Auth credential.</param>
+    /// <returns>The signed in <c>IFirebaseUser</c> object.</returns>
+    Task<IFirebaseUser> LinkWithCredentialAsync(AuthCredential credential);
+}

--- a/src/Auth/Platforms/iOS/FirebaseAuthImplementation.cs
+++ b/src/Auth/Platforms/iOS/FirebaseAuthImplementation.cs
@@ -67,7 +67,8 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return await SignInWithCredentialAsync(credential);
     }
 
-    private async Task<IFirebaseUser> SignInWithCredentialAsync(AuthCredential credential)
+    /// <inheritdoc/>
+    public async Task<IFirebaseUser> SignInWithCredentialAsync(AuthCredential credential)
     {
         var authResult = await FirebaseAuthExceptionFactory.Wrap(
             () => _firebaseAuth.SignInWithCredentialAsync(credential)
@@ -141,7 +142,8 @@ public sealed class FirebaseAuthImplementation : DisposableBase, IFirebaseAuth
         return await LinkWithCredentialAsync(credential);
     }
 
-    private async Task<IFirebaseUser> LinkWithCredentialAsync(AuthCredential credential)
+    /// <inheritdoc/>
+    public async Task<IFirebaseUser> LinkWithCredentialAsync(AuthCredential credential)
     {
         var currentUser = _firebaseAuth.CurrentUser;
         if(currentUser is null) {

--- a/src/Auth/Platforms/iOS/IFirebaseAuth.cs
+++ b/src/Auth/Platforms/iOS/IFirebaseAuth.cs
@@ -1,0 +1,20 @@
+using Firebase.Auth;
+
+namespace Plugin.Firebase.Auth;
+
+public partial interface IFirebaseAuth
+{
+    /// <summary>
+    /// Signs in using a native Firebase Auth credential.
+    /// </summary>
+    /// <param name="credential">The native iOS Firebase Auth credential.</param>
+    /// <returns>The signed in <c>IFirebaseUser</c> object.</returns>
+    Task<IFirebaseUser> SignInWithCredentialAsync(AuthCredential credential);
+
+    /// <summary>
+    /// Links the signed in user with a native Firebase Auth credential.
+    /// </summary>
+    /// <param name="credential">The native iOS Firebase Auth credential.</param>
+    /// <returns>The signed in <c>IFirebaseUser</c> object.</returns>
+    Task<IFirebaseUser> LinkWithCredentialAsync(AuthCredential credential);
+}

--- a/src/Auth/Shared/IFirebaseAuth.cs
+++ b/src/Auth/Shared/IFirebaseAuth.cs
@@ -3,7 +3,7 @@ namespace Plugin.Firebase.Auth;
 /// <summary>
 /// Manages authentication for Firebase apps.
 /// </summary>
-public interface IFirebaseAuth : IDisposable
+public partial interface IFirebaseAuth : IDisposable
 {
     /// <summary>
     /// Starts the phone number authentication flow by sending a verification code to the specified phone number.

--- a/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
@@ -35,6 +35,23 @@ namespace Plugin.Firebase.IntegrationTests.Auth
         }
 
         [Fact]
+        public async Task signs_in_user_with_native_credential()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var email = CreateUniqueEmail("native-sign-in");
+            await sut.CreateUserAsync(email, "123456");
+            await sut.SignOutAsync();
+            var credential = CreateNativeEmailCredential(email, "123456");
+
+            var user = await sut.SignInWithCredentialAsync(credential);
+
+            Assert.Equal(email, user.Email);
+            Assert.NotNull(sut.CurrentUser);
+            Assert.Equal(email, sut.CurrentUser.Email);
+            Assert.Equal(user.Uid, sut.CurrentUser.Uid);
+        }
+
+        [Fact]
         public async Task sign_in_with_email_and_password_creates_user_automatically()
         {
             var sut = CrossFirebaseAuth.Current;
@@ -71,6 +88,19 @@ namespace Plugin.Firebase.IntegrationTests.Auth
         }
 
         [Fact]
+        public async Task throws_cross_platform_exception_for_invalid_native_credential()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var credential = CreateNativeEmailCredential(CreateUniqueEmail("invalid-native-sign-in"), "000000");
+
+            var ex = await Assert.ThrowsAnyAsync<CrossPlatformFirebaseAuthException>(
+                () => sut.SignInWithCredentialAsync(credential)
+            );
+
+            AssertNativeAuthExceptionCaptured(ex);
+        }
+
+        [Fact]
         public async Task signs_in_user_anonymously()
         {
             var sut = CrossFirebaseAuth.Current;
@@ -92,6 +122,25 @@ namespace Plugin.Firebase.IntegrationTests.Auth
             var linkedUser = await sut.LinkWithEmailAndPasswordAsync(email, "123456");
 
             Assert.Equal(anonymousUser.Uid, linkedUser.Uid);
+            Assert.Equal(anonymousUser.Uid, sut.CurrentUser.Uid);
+            Assert.False(linkedUser.IsAnonymous);
+            Assert.False(sut.CurrentUser.IsAnonymous);
+            Assert.Equal(email, linkedUser.Email);
+            Assert.Equal(email, sut.CurrentUser.Email);
+        }
+
+        [Fact]
+        public async Task links_anonymous_user_with_native_credential()
+        {
+            var sut = CrossFirebaseAuth.Current;
+            var anonymousUser = await sut.SignInAnonymouslyAsync();
+            var email = CreateUniqueEmail("native-link");
+            var credential = CreateNativeEmailCredential(email, "123456");
+
+            var linkedUser = await sut.LinkWithCredentialAsync(credential);
+
+            Assert.Equal(anonymousUser.Uid, linkedUser.Uid);
+            Assert.NotNull(sut.CurrentUser);
             Assert.Equal(anonymousUser.Uid, sut.CurrentUser.Uid);
             Assert.False(linkedUser.IsAnonymous);
             Assert.False(sut.CurrentUser.IsAnonymous);
@@ -338,6 +387,20 @@ namespace Plugin.Firebase.IntegrationTests.Auth
         private static string CreateUniqueEmail(string prefix)
         {
             return $"{prefix}-{Guid.NewGuid():N}@test.com";
+        }
+
+        private static global::Firebase.Auth.AuthCredential CreateNativeEmailCredential(
+            string email,
+            string password
+        )
+        {
+#if ANDROID
+            return global::Firebase.Auth.EmailAuthProvider.GetCredential(email, password);
+#elif IOS
+            return global::Firebase.Auth.EmailAuthProvider.GetCredentialFromPassword(email, password);
+#else
+            throw new PlatformNotSupportedException();
+#endif
         }
     }
 }


### PR DESCRIPTION
## Summary
- Expose platform-specific IFirebaseAuth methods for native Firebase AuthCredential sign-in and linking.
- Keep native credential creation in platform code while routing credential consumption through CrossFirebaseAuth.Current.
- Add Auth integration coverage for native credential sign-in, linking, and invalid credential wrapping.
- Document native provider credential usage in Auth docs.

## Validation
- dotnet build src/Auth/Auth.csproj -f net9.0
- dotnet build src/Auth/Auth.csproj -f net9.0-android
- dotnet build src/Auth/Auth.csproj -f net9.0-ios
- dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj
- dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-android -m:1
- dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -c Debug -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false -m:1
- dotnet format Plugin.Firebase.sln --include src/Auth/Shared/IFirebaseAuth.cs src/Auth/Platforms/Android/IFirebaseAuth.cs src/Auth/Platforms/iOS/IFirebaseAuth.cs src/Auth/Platforms/Android/FirebaseAuthImplementation.cs src/Auth/Platforms/iOS/FirebaseAuthImplementation.cs tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs
- git diff --check

Runtime XHarness tests were not run because no Android device was attached and no local Auth emulator was listening on port 9099.