### PR TITLE
[codex] Add Analytics default event parameters

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -59,6 +59,26 @@ Since code should be documenting itself you can also take a look at the followin
 - [src/.../IFirebaseAnalytics.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Analytics/Shared/IFirebaseAnalytics.cs)
 - [tests/.../AnalyticsFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/Plugin.Firebase.IntegrationTests/Analytics/AnalyticsFixture.cs)
 
+### Default event parameters
+
+Default event parameters are included with every subsequent event. Event-specific parameters take precedence when they use the
+same name.
+
+```c#
+var analytics = CrossFirebaseAnalytics.Current;
+
+analytics.SetDefaultEventParameters(
+    ("app_theme", "dark"),
+    ("screen_depth", 3L),
+    ("cart_value", 13.37));
+
+analytics.LogEvent("screen_view");
+
+analytics.SetDefaultEventParameters((IDictionary<string, object>) null);
+```
+
+Passing a typed null to the dictionary overload clears all default event parameters.
+
 ## Release notes
 - Version 3.1.2
   - Add collections support for Analytics (PR #432)

--- a/src/Analytics/Platforms/Android/FirebaseAnalyticsImplementation.cs
+++ b/src/Analytics/Platforms/Android/FirebaseAnalyticsImplementation.cs
@@ -30,6 +30,16 @@ public sealed class FirebaseAnalyticsImplementation : DisposableBase, IFirebaseA
         LogEvent(eventName, parameters?.ToDictionary(x => x.parameterName, x => x.parameterValue));
     }
 
+    public void SetDefaultEventParameters(IDictionary<string, object> parameters)
+    {
+        GetInitializedAnalytics().SetDefaultEventParameters(parameters?.ToBundle());
+    }
+
+    public void SetDefaultEventParameters(params (string parameterName, object parameterValue)[] parameters)
+    {
+        SetDefaultEventParameters(parameters?.ToDictionary(x => x.parameterName, x => x.parameterValue));
+    }
+
     public void SetUserId(string id)
     {
         GetInitializedAnalytics().SetUserId(id);

--- a/src/Analytics/Platforms/iOS/FirebaseAnalyticsImplementation.cs
+++ b/src/Analytics/Platforms/iOS/FirebaseAnalyticsImplementation.cs
@@ -31,6 +31,20 @@ public sealed class FirebaseAnalyticsImplementation : DisposableBase, IFirebaseA
     }
 
     /// <inheritdoc/>
+    public void SetDefaultEventParameters(IDictionary<string, object> parameters)
+    {
+        FirebaseAnalytics.SetDefaultEventParameters(parameters?.ToNSDictionary());
+    }
+
+    /// <inheritdoc/>
+    public void SetDefaultEventParameters(
+        params (string parameterName, object parameterValue)[] parameters
+    )
+    {
+        SetDefaultEventParameters(parameters?.ToDictionary(x => x.parameterName, x => x.parameterValue));
+    }
+
+    /// <inheritdoc/>
     public void SetUserId(string id)
     {
         FirebaseAnalytics.SetUserId(id);

--- a/src/Analytics/Shared/IFirebaseAnalytics.cs
+++ b/src/Analytics/Shared/IFirebaseAnalytics.cs
@@ -51,6 +51,30 @@ public interface IFirebaseAnalytics : IDisposable
     void LogEvent(string eventName, params (string parameterName, object parameterValue)[] parameters);
 
     /// <summary>
+    /// Sets parameters that are included with every subsequent event. Event-specific parameters take precedence when they use
+    /// the same name. Passing null clears all default event parameters.
+    /// </summary>
+    /// <param name="parameters">
+    /// The dictionary of default event parameters. Parameter names can be up to 40 characters long and must start with an
+    /// alphabetic character and contain only alphanumeric characters and underscores. Only NSString and NSNumber (signed 64-bit
+    /// integer and 64-bit floating-point number) parameter types are supported. NSString parameter values can be up to 100
+    /// characters long. The “firebase_”, “google_”, and “ga_” prefixes are reserved and should not be used for parameter names.
+    /// </param>
+    void SetDefaultEventParameters(IDictionary<string, object> parameters);
+
+    /// <summary>
+    /// Sets parameters that are included with every subsequent event. Event-specific parameters take precedence when they use
+    /// the same name.
+    /// </summary>
+    /// <param name="parameters">
+    /// The default event parameters as tuples. Parameter names can be up to 40 characters long and must start with an alphabetic
+    /// character and contain only alphanumeric characters and underscores. Only NSString and NSNumber (signed 64-bit integer and
+    /// 64-bit floating-point number) parameter types are supported. NSString parameter values can be up to 100 characters long.
+    /// The “firebase_”, “google_”, and “ga_” prefixes are reserved and should not be used for parameter names.
+    /// </param>
+    void SetDefaultEventParameters(params (string parameterName, object parameterValue)[] parameters);
+
+    /// <summary>
     /// Sets the user ID property. This feature must be used in accordance with Google’s Privacy Policy
     /// </summary>
     /// <param name="id">

--- a/tests/Plugin.Firebase.IntegrationTests/Analytics/AnalyticsFixture.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Analytics/AnalyticsFixture.cs
@@ -21,17 +21,28 @@ namespace Plugin.Firebase.IntegrationTests.Analytics
             try {
                 firebaseAnalyticsField.SetValue(null, null);
 
-                var exception = Assert.Throws<InvalidOperationException>(
+                var logEventException = Assert.Throws<InvalidOperationException>(
                     () => CrossFirebaseAnalytics.Current.LogEvent("test_uninitialized_analytics_guard")
                 );
+                AssertAnalyticsNotInitializedException(logEventException);
 
-                Assert.Contains("Firebase Analytics has not been initialized on Android", exception.Message);
-                Assert.Contains("FirebaseAnalyticsImplementation.Initialize(activity)", exception.Message);
-                Assert.Contains("isAnalyticsEnabled: true", exception.Message);
+                var setDefaultEventParametersException = Assert.Throws<InvalidOperationException>(
+                    () => CrossFirebaseAnalytics.Current.SetDefaultEventParameters(new Dictionary<string, object> {
+                        { "default_string", "some_value" }
+                    })
+                );
+                AssertAnalyticsNotInitializedException(setDefaultEventParametersException);
             }
             finally {
                 firebaseAnalyticsField.SetValue(null, originalFirebaseAnalytics);
             }
+        }
+
+        private static void AssertAnalyticsNotInitializedException(InvalidOperationException exception)
+        {
+            Assert.Contains("Firebase Analytics has not been initialized on Android", exception.Message);
+            Assert.Contains("FirebaseAnalyticsImplementation.Initialize(activity)", exception.Message);
+            Assert.Contains("isAnalyticsEnabled: true", exception.Message);
         }
 #endif
 
@@ -64,6 +75,49 @@ namespace Plugin.Firebase.IntegrationTests.Analytics
                 { "some_dictionary", new Dictionary<string, object> { { "some_key", "some_value" } } },
                 { "some_dictionary_collection", new [] { new Dictionary<string, object> { { "some_key", "some_value" } } }}
             });
+        }
+
+        [RealFirebaseFact]
+        public void does_not_throw_any_exception_when_setting_default_event_parameters_via_dictionary()
+        {
+            var sut = CrossFirebaseAnalytics.Current;
+
+            try {
+                sut.SetDefaultEventParameters(new Dictionary<string, object> {
+                    { "default_string", "some_value" },
+                    { "default_long", 1337L },
+                    { "default_double", 13.37 }
+                });
+
+                sut.LogEvent("test_with_default_dictionary_parameters");
+            }
+            finally {
+                sut.SetDefaultEventParameters((IDictionary<string, object>) null);
+            }
+        }
+
+        [RealFirebaseFact]
+        public void does_not_throw_any_exception_when_setting_default_event_parameters_via_tuples()
+        {
+            var sut = CrossFirebaseAnalytics.Current;
+
+            try {
+                sut.SetDefaultEventParameters(
+                    ("default_string", "some_value"),
+                    ("default_long", 1337L),
+                    ("default_double", 13.37));
+
+                sut.LogEvent("test_with_default_tuple_parameters");
+            }
+            finally {
+                sut.SetDefaultEventParameters((IDictionary<string, object>) null);
+            }
+        }
+
+        [RealFirebaseFact]
+        public void does_not_throw_any_exception_when_clearing_default_event_parameters()
+        {
+            CrossFirebaseAnalytics.Current.SetDefaultEventParameters((IDictionary<string, object>) null);
         }
 
         [RealFirebaseFact]


### PR DESCRIPTION
## Summary
- expose `SetDefaultEventParameters` on `IFirebaseAnalytics` with dictionary and tuple overloads
- pass through to the native Android and iOS Firebase Analytics APIs using the existing parameter converters
- add Analytics integration smoke coverage and document typed-null clearing

Closes #431.

## Validation
- `dotnet build src/Analytics/Analytics.csproj -c Release -f net9.0`
- `dotnet build src/Analytics/Analytics.csproj -c Release -f net9.0-ios`
- `dotnet build src/Analytics/Analytics.csproj -c Release -f net9.0-android`
- Android integration app Release build passed before rebasing, with an existing Auth nullable warning
- iOS unsigned Debug simulator integration app build passed before rebasing

## Notes
- Real Firebase device integration tests were not run locally.
