### PR TITLE
[codex] Add integration harness tooling

### DIFF
--- a/.github/workflows/integration-emulators.yml
+++ b/.github/workflows/integration-emulators.yml
@@ -40,11 +40,7 @@ jobs:
         run: dotnet workload install maui --source https://api.nuget.org/v3/index.json
 
       - name: Install Firebase CLI and XHarness
-        run: |
-          npm install --global firebase-tools@15.15.0
-          dotnet tool install --global Microsoft.DotNet.XHarness.CLI \
-            --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json \
-            --version "11.0.0-prerelease.26224.1"
+        run: scripts/install-integration-test-tools.sh
 
       - name: Build Cloud Functions
         run: |
@@ -93,7 +89,7 @@ jobs:
           arch: x86_64
           profile: pixel_6
           script: |
-            bash -lc 'export PATH="$PATH:$HOME/.dotnet/tools"; cd tests/cloud-functions && firebase emulators:exec --project "$FIREBASE_PROJECT_ID" --only auth,firestore,functions,storage "node scripts/seed-auth-emulator.js && xharness android test --timeout=00:10:00 --launch-timeout=00:10:00 --package-name $ANDROID_PACKAGE_ID --instrumentation devicerunners.xharness.maui.XHarnessInstrumentation --app $ANDROID_APK --output-directory ../../artifacts/test-results/android --verbosity=Debug"'
+            bash -lc '"$GITHUB_WORKSPACE/scripts/run-integration-emulators.sh" android'
 
       - name: Summarize Android test results
         if: always()
@@ -127,11 +123,7 @@ jobs:
         run: sudo "$DOTNET_ROOT/dotnet" workload install maui --source https://api.nuget.org/v3/index.json
 
       - name: Install Firebase CLI and XHarness
-        run: |
-          npm install --global firebase-tools@15.15.0
-          dotnet tool install --global Microsoft.DotNet.XHarness.CLI \
-            --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json \
-            --version "11.0.0-prerelease.26224.1"
+        run: scripts/install-integration-test-tools.sh
 
       - name: Select Xcode for .NET iOS workload
         run: |
@@ -180,13 +172,7 @@ jobs:
           xcrun simctl bootstatus "$DEVICE_ID" -b
 
       - name: Run iOS integration tests against emulators
-        run: |
-          export PATH="$PATH:$HOME/.dotnet/tools"
-          cd tests/cloud-functions
-          firebase emulators:exec \
-              --project "$FIREBASE_PROJECT_ID" \
-              --only auth,firestore,functions,storage \
-              "node scripts/seed-auth-emulator.js && xharness apple test --target ios-simulator-64 --device $DEVICE_ID --timeout=00:10:00 --launch-timeout=00:10:00 --app ../Plugin.Firebase.IntegrationTests/bin/Debug/net9.0-ios/iossimulator-arm64/Plugin.Firebase.IntegrationTests.app --output-directory ../../artifacts/test-results/ios --set-env=PLUGIN_FIREBASE_TEST_BACKEND=emulator"
+        run: scripts/run-integration-emulators.sh ios
 
       - name: Cleanup iOS simulator
         if: always()

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -69,10 +69,11 @@ node scripts/seed-auth-emulator.js
 For one-shot local runs, wrap the device command with `emulators:exec`:
 
 ```
-cd tests/cloud-functions
-firebase emulators:exec --project demo-pluginfirebase-integrationtests --only auth,firestore,functions,storage \
-  "node scripts/seed-auth-emulator.js && <xharness command>"
+scripts/run-integration-emulators.sh android
+DEVICE_ID=<simulator-udid> scripts/run-integration-emulators.sh ios
 ```
+
+The runner script calls `scripts/check-integration-environment.sh android|ios` before launching emulators. Run the preflight directly when diagnosing setup issues; it checks required CLIs, built app output, Functions build output, emulator ports, and device/simulator availability. Set `SKIP_INTEGRATION_PREFLIGHT=1` only when a CI step has already guaranteed those conditions.
 
 Default emulator endpoints are:
 
@@ -85,9 +86,9 @@ Default emulator endpoints are:
 
 Override them with `PLUGIN_FIREBASE_<SERVICE>_EMULATOR_HOST` / `PLUGIN_FIREBASE_<SERVICE>_EMULATOR_PORT`, or Android system properties like `debug.pluginfirebase.auth.host` and `debug.pluginfirebase.auth.port`.
 
-The Auth emulator seed script recreates `custom-claims@test.com` with password `123456` and custom claims `{ "is_awesome": true }`. The `updates_user_email` test remains skipped on iOS and Android because Firebase's direct email update flow now depends on deprecated project configuration.
+The Auth emulator seed script recreates `custom-claims@test.com` with password `123456` and the nested custom claims asserted by the Auth fixture. The `updates_user_email` test remains skipped on iOS and Android because Firebase's direct email update flow now depends on deprecated project configuration.
 
-The `.github/workflows/integration-emulators.yml` workflow runs the emulator-backed Android and iOS suites on pull requests and can also be started manually with `workflow_dispatch`. Branch protection should require the `integration-emulators-android` and `integration-emulators-ios` checks.
+The `.github/workflows/integration-emulators.yml` workflow runs the emulator-backed Android and iOS suites on pull requests and can also be started manually with `workflow_dispatch`. Branch protection should require the `integration-emulators-android` and `integration-emulators-ios` checks. Its GitHub step summary includes xUnit totals, failed tests, skipped tests, slow tests, and recent `[TEST START]` breadcrumbs when logs are present.
 
 Build the iOS test app for a simulator:
 ```
@@ -105,39 +106,24 @@ dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationT
   -f net9.0-android
 ```
 
-The default integration-test host now uses the DeviceRunners XHarness runner so tests can be launched from the CLI. Install the tool once:
+The default integration-test host now uses the DeviceRunners XHarness runner so tests can be launched from the CLI. Install the local runner tools once:
 ```
-dotnet tool install --global Microsoft.DotNet.XHarness.CLI \
-  --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json \
-  --version "11.0.0-prerelease*"
+scripts/install-integration-test-tools.sh
 ```
 
 The installed command is `xharness`. If your shell cannot find it, make sure `~/.dotnet/tools` is on your `PATH`.
 
 Run the iOS suite on a specific simulator:
 ```
-xharness apple test \
-  --target ios-simulator-64 \
-  --device <simulator-udid> \
-  --timeout="00:10:00" \
-  --launch-timeout=00:10:00 \
-  --app tests/Plugin.Firebase.IntegrationTests/bin/Debug/net9.0-ios/iossimulator-arm64/Plugin.Firebase.IntegrationTests.app \
-  --output-directory artifacts/test-results/ios
+DEVICE_ID=<simulator-udid> scripts/run-integration-emulators.sh ios
 ```
 
 Run the Android suite on the currently running emulator:
 ```
-xharness android test \
-  --timeout="00:10:00" \
-  --launch-timeout=00:10:00 \
-  --package-name <package-id> \
-  --instrumentation devicerunners.xharness.maui.XHarnessInstrumentation \
-  --app tests/Plugin.Firebase.IntegrationTests/bin/Debug/net9.0-android/<package-id>-Signed.apk \
-  --output-directory artifacts/test-results/android \
-  --verbosity=Debug
+scripts/run-integration-emulators.sh android
 ```
 
-Use `xcrun simctl list devices available` to find a simulator UDID and `adb devices` to verify the Android emulator is online before running the Android command. XHarness uses the only connected adb target by default; if `adb devices` lists more than one device or emulator, add `--device-id <adb-device-id>` to the `xharness android test` command. If you keep the default application ids, `<package-id>` is `plugin.firebase.integrationtests`. If you override the ids in `Plugin.Firebase.IntegrationTests.props.user`, use the overridden Android package id in both `--package-name` and the APK filename.
+Use `xcrun simctl list devices available` to find a simulator UDID and `adb devices` to verify the Android emulator is online before running the Android command. The preflight script performs these checks automatically before emulator-backed runs. XHarness uses the only connected adb target by default; if `adb devices` lists more than one device or emulator, add `--device-id <adb-device-id>` to the `xharness android test` command. If you keep the default application ids, `<package-id>` is `plugin.firebase.integrationtests`. If you override the ids in `Plugin.Firebase.IntegrationTests.props.user`, use the overridden Android package id in both `--package-name` and the APK filename.
 
 ### Real Firebase backend (opt-in)
 
@@ -150,9 +136,9 @@ Make sure your Firebase app registrations and generated config files match the i
 
 For real Firebase Auth integration tests:
 - Enable the `Email/Password` and `Anonymous` sign-in providers.
-- Create `custom-claims@test.com` with password `123456` and custom claims `{ "is_awesome": true }`.
+- Create `custom-claims@test.com` with password `123456` and the nested custom claims used by `tests/cloud-functions/scripts/seed-auth-emulator.js`.
 
-Real-project Remote Config tests expect published values for `remote_string`, `remote_long`, `remote_double`, and `remote_bool`; see `docs/BUILDING.md` for the full setup table.
+Real-project Cloud Functions, Storage, and Remote Config tests expect deployed test functions, bucket seed files, and published Remote Config values; see `docs/BUILDING.md` for the full setup tables.
 
 If you want the interactive visual runner instead, opt in explicitly:
 - On iOS simulators, relaunch with `SIMCTL_CHILD_PLUGIN_FIREBASE_USE_VISUAL_RUNNER=1`.

--- a/Plugin.Firebase.sln.DotSettings
+++ b/Plugin.Firebase.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OS/@EntryIndexedValue">OS</s:String></wpf:ResourceDictionary>

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -120,12 +120,10 @@ dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationT
   -f net9.0-android
 ```
 
-The default integration-test host now uses the DeviceRunners XHarness runner so tests can be launched from the CLI. Install the tool once:
+The default integration-test host now uses the DeviceRunners XHarness runner so tests can be launched from the CLI. Install the local runner tools once:
 
 ```sh
-dotnet tool install --global Microsoft.DotNet.XHarness.CLI \
-  --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json \
-  --version "11.0.0-prerelease*"
+scripts/install-integration-test-tools.sh
 ```
 
 The installed command is `xharness`. If your shell cannot find it, make sure `~/.dotnet/tools` is on your `PATH`.
@@ -133,29 +131,16 @@ The installed command is `xharness`. If your shell cannot find it, make sure `~/
 iOS integration tests run on a specific simulator:
 
 ```sh
-xharness apple test \
-  --target ios-simulator-64 \
-  --device <simulator-udid> \
-  --timeout="00:10:00" \
-  --launch-timeout=00:10:00 \
-  --app tests/Plugin.Firebase.IntegrationTests/bin/Debug/net9.0-ios/iossimulator-arm64/Plugin.Firebase.IntegrationTests.app \
-  --output-directory artifacts/test-results/ios
+DEVICE_ID=<simulator-udid> scripts/run-integration-emulators.sh ios
 ```
 
 Android integration tests run on the currently running emulator:
 
 ```sh
-xharness android test \
-  --timeout="00:10:00" \
-  --launch-timeout=00:10:00 \
-  --package-name <package-id> \
-  --instrumentation devicerunners.xharness.maui.XHarnessInstrumentation \
-  --app tests/Plugin.Firebase.IntegrationTests/bin/Debug/net9.0-android/<package-id>-Signed.apk \
-  --output-directory artifacts/test-results/android \
-  --verbosity=Debug
+scripts/run-integration-emulators.sh android
 ```
 
-Use `xcrun simctl list devices available` to discover simulator UDIDs and `adb devices` to verify the Android emulator is online before running the Android command. XHarness uses the only connected adb target by default; if `adb devices` lists more than one device or emulator, add `--device-id <adb-device-id>` to the `xharness android test` command. If you keep the default application ids, `<package-id>` is `plugin.firebase.integrationtests`. If you override the ids in `Plugin.Firebase.IntegrationTests.props.user`, use the overridden Android package id in both `--package-name` and the APK filename.
+Use `xcrun simctl list devices available` to discover simulator UDIDs and `adb devices` to verify the Android emulator is online before running the Android command. `scripts/run-integration-emulators.sh` calls `scripts/check-integration-environment.sh android|ios` first to check CLIs, built app output, Functions build output, emulator ports, and target availability. Set `SKIP_INTEGRATION_PREFLIGHT=1` only for CI edge cases where another step already guarantees the environment. XHarness uses the only connected adb target by default; if `adb devices` lists more than one device or emulator, add `--device-id <adb-device-id>` to the `xharness android test` command. If you keep the default application ids, `<package-id>` is `plugin.firebase.integrationtests`. If you override the ids in `Plugin.Firebase.IntegrationTests.props.user`, use the overridden Android package id in both `--package-name` and the APK filename.
 
 The interactive visual runner is still available, but it is opt-in:
 
@@ -165,7 +150,7 @@ The interactive visual runner is still available, but it is opt-in:
 Harness notes:
 
 - The integration fixtures run sequentially on purpose. The suite shares backend state, emulator state, and cleanup code across tests, so disabling xUnit parallelization avoids order-dependent failures that are hard to reproduce on device runners.
-- Each test writes `[TEST START]` and `[TEST END]` breadcrumbs to the runner output. If a CLI run appears hung, check the xharness log, simulator console output, or Android logcat to see which test last started.
+- Each test writes `[TEST START]` and `[TEST END]` breadcrumbs to the runner output. If a CLI run appears hung, check the xharness log, simulator console output, or Android logcat to see which test last started. The CI summary includes recent breadcrumbs plus failed, skipped, and slow test details when XML/log data is available.
 - iOS simulator builds ad-hoc re-sign the generated app bundle and bundled .NET runtime libraries after `dotnet build`. This is a simulator-only workaround for Xcode 26 / macOS 26 code-signature validation and is not required for real-device builds.
 
 ## Emulator-backed integration tests (default)
@@ -192,12 +177,14 @@ Seed the Auth emulator before launching the device test app:
 node scripts/seed-auth-emulator.js
 ```
 
-For one-shot runs, wrap the XHarness command with `emulators:exec`:
+For one-shot emulator-backed runs, use the shared runner script:
 
 ```sh
-firebase emulators:exec --project demo-pluginfirebase-integrationtests --only auth,firestore,functions,storage \
-  "node scripts/seed-auth-emulator.js && <xharness command>"
+scripts/run-integration-emulators.sh android
+DEVICE_ID=<simulator-udid> scripts/run-integration-emulators.sh ios
 ```
+
+Run `scripts/check-integration-environment.sh android|ios` directly for a fast setup check without launching emulators.
 
 Default emulator ports are Auth `9099`, Firestore `8080`, Functions `5001`, and Storage `9199`. The app uses `localhost` on iOS and `10.0.2.2` on Android unless overridden with `PLUGIN_FIREBASE_<SERVICE>_EMULATOR_HOST` / `PLUGIN_FIREBASE_<SERVICE>_EMULATOR_PORT` or Android system properties such as `debug.pluginfirebase.auth.host`.
 
@@ -205,7 +192,7 @@ Analytics, Remote Config, Performance Monitoring ingestion, and App Check token 
 
 Performance Monitoring still runs wrapper contract tests on the default emulator-backed app because custom traces and HTTP metrics can be created with dummy Firebase options. Those tests validate the local SDK calls and wrapper behavior only; automated tests do not wait for traces or metrics to appear in the Firebase Console.
 
-The `.github/workflows/integration-emulators.yml` workflow runs the emulator-backed Android and iOS suites as PR-gated checks and still supports manual reruns with `workflow_dispatch`. Branch protection should require the `integration-emulators-android` and `integration-emulators-ios` checks.
+The `.github/workflows/integration-emulators.yml` workflow runs the emulator-backed Android and iOS suites as PR-gated checks and still supports manual reruns with `workflow_dispatch`. Branch protection should require the `integration-emulators-android` and `integration-emulators-ios` checks. Its summary output keeps the totals table and adds failures, skips, slow tests, and recent test breadcrumbs when available.
 
 ## Real Firebase project setup for integration tests
 
@@ -242,12 +229,33 @@ Make sure your Firebase app registrations and generated config files match the i
 
    | Email | Password | Custom Claims |
    |---|---|---|
-   | `custom-claims@test.com` | `123456` | `{ "is_awesome": true }` |
+   | `custom-claims@test.com` | `123456` | See the claim payload below |
 
    Custom claims must be set via the Firebase Admin SDK or a Cloud Function — they cannot be set from the Firebase Console UI. Example using the Admin SDK:
    ```js
    admin.auth().getUserByEmail('custom-claims@test.com')
-     .then(user => admin.auth().setCustomUserClaims(user.uid, { is_awesome: true }));
+     .then(user => admin.auth().setCustomUserClaims(user.uid, {
+       is_awesome: true,
+       nested_object: {
+         enabled: true,
+         roles: ['admin', 'tester'],
+         metadata: {
+           source: 'emulator',
+           version: 2,
+         },
+         history: [
+           { action: 'created', count: 1 },
+           { action: 'updated', count: 2 },
+         ],
+         score: 7,
+         ratio: 1.5,
+         optional: null,
+       },
+       nested_array: [
+         { name: 'first', flags: [true, false] },
+         { name: 'second', metadata: { source: 'emulator' } },
+       ],
+     }));
    ```
 
 3. All other test users (`sign-in-with-pw@test.com`, `to-delete@test.com`, etc.) are created and cleaned up automatically by the test suite via `createsUserAutomatically`.
@@ -317,6 +325,10 @@ Required functions:
 | `returnNumberPayload` | `https.onCall` | Verifies callable number response deserialization |
 | `returnBooleanPayload` | `https.onCall` | Verifies callable boolean response deserialization |
 | `returnNullPayload` | `https.onCall` | Verifies callable null response deserialization |
+| `createCustomToken` | `https.onCall` | Mints custom tokens for Auth acceptance tests |
+| `echoAuthContext` | `https.onCall` | Verifies callable auth context propagation |
+| `throwStructuredError` | `https.onCall` | Verifies callable error propagation |
+| `regionalPing` | `https.onCall`, `southamerica-east1` | Verifies configured Functions regions |
 | `addMessage` | `https.onRequest` | Writes to Firestore `messages` collection |
 | `makeUppercase` | `firestore.onCreate` | Triggered on `/messages/{documentId}` |
 | `echo` | `https.onRequest` | Echoes request body |

--- a/scripts/check-integration-environment.sh
+++ b/scripts/check-integration-environment.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 android|ios" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+platform="$1"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+project_path="${repo_root}/tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj"
+functions_dir="${repo_root}/tests/cloud-functions/functions"
+
+export PATH="${PATH}:${HOME}/.dotnet/tools"
+
+errors=()
+warnings=()
+errors_count=0
+warnings_count=0
+
+add_error() {
+  errors+=("$1")
+  errors_count=$((errors_count + 1))
+}
+
+add_warning() {
+  warnings+=("$1")
+  warnings_count=$((warnings_count + 1))
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    add_error "Missing required command: $1"
+  fi
+}
+
+require_file() {
+  if [ ! -f "$1" ]; then
+    add_error "Missing required file: $1"
+  fi
+}
+
+require_dir() {
+  if [ ! -d "$1" ]; then
+    add_error "Missing required directory: $1"
+  fi
+}
+
+is_port_listening() {
+  local port="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1
+    return
+  fi
+
+  if command -v nc >/dev/null 2>&1; then
+    nc -z 127.0.0.1 "${port}" >/dev/null 2>&1
+    return
+  fi
+
+  return 1
+}
+
+check_emulator_ports() {
+  if [ "${ALLOW_BUSY_EMULATOR_PORTS:-0}" = "1" ]; then
+    add_warning "Skipping emulator port availability checks because ALLOW_BUSY_EMULATOR_PORTS=1."
+    return
+  fi
+
+  local busy_ports=()
+  local busy_ports_count=0
+  for port in 9099 8080 5001 9199; do
+    if is_port_listening "${port}"; then
+      busy_ports+=("${port}")
+      busy_ports_count=$((busy_ports_count + 1))
+    fi
+  done
+
+  if [ "${busy_ports_count}" -gt 0 ]; then
+    add_error "Firebase emulator port(s) already in use: ${busy_ports[*]}. Stop the existing process or set ALLOW_BUSY_EMULATOR_PORTS=1."
+  fi
+}
+
+check_common_environment() {
+  require_command dotnet
+  require_command node
+  require_command npm
+  require_command firebase
+  require_command xharness
+
+  require_file "${project_path}"
+  require_file "${functions_dir}/package.json"
+  require_dir "${functions_dir}/node_modules"
+  require_file "${functions_dir}/lib/index.js"
+  require_file "${repo_root}/tests/cloud-functions/scripts/seed-auth-emulator.js"
+
+  check_emulator_ports
+}
+
+check_android_environment() {
+  require_command adb
+
+  local apk="${ANDROID_APK:-}"
+  if [ -z "${apk}" ]; then
+    apk="$(find "${repo_root}/tests/Plugin.Firebase.IntegrationTests/bin/Debug/net9.0-android" \
+      -name "*-Signed.apk" \
+      -type f \
+      -print \
+      -quit 2>/dev/null || true)"
+  fi
+
+  if [ -z "${apk}" ] || [ ! -f "${apk}" ]; then
+    add_error "Missing built Android test APK. Build net9.0-android first or set ANDROID_APK."
+  fi
+
+  if command -v adb >/dev/null 2>&1; then
+    if ! adb devices | awk 'NR > 1 && $2 == "device" { found = 1 } END { exit found ? 0 : 1 }'; then
+      add_error "No online Android adb device or emulator was found."
+    fi
+  fi
+}
+
+check_ios_environment() {
+  require_command xcrun
+
+  local app_path="${IOS_APP_PATH:-${repo_root}/tests/Plugin.Firebase.IntegrationTests/bin/Debug/net9.0-ios/iossimulator-arm64/Plugin.Firebase.IntegrationTests.app}"
+  if [ ! -d "${app_path}" ]; then
+    add_error "Missing built iOS simulator app. Build net9.0-ios iossimulator-arm64 first or set IOS_APP_PATH."
+  fi
+
+  if [ -z "${DEVICE_ID:-}" ]; then
+    add_error "DEVICE_ID must be set to an available iOS simulator UDID."
+  elif command -v xcrun >/dev/null 2>&1; then
+    if ! xcrun simctl list devices available | grep -F "${DEVICE_ID}" >/dev/null 2>&1; then
+      add_error "DEVICE_ID '${DEVICE_ID}' is not an available iOS simulator."
+    fi
+  fi
+}
+
+case "${platform}" in
+  android)
+    check_common_environment
+    check_android_environment
+    ;;
+  ios)
+    check_common_environment
+    check_ios_environment
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+if [ "${warnings_count}" -gt 0 ]; then
+  for warning in "${warnings[@]}"; do
+    echo "warning: ${warning}" >&2
+  done
+fi
+
+if [ "${errors_count}" -gt 0 ]; then
+  echo "Integration environment preflight failed:" >&2
+  for error in "${errors[@]}"; do
+    echo " - ${error}" >&2
+  done
+  exit 1
+fi
+
+echo "Integration environment preflight passed for ${platform}."

--- a/scripts/install-integration-test-tools.sh
+++ b/scripts/install-integration-test-tools.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+firebase_tools_version="${FIREBASE_TOOLS_VERSION:-15.15.0}"
+xharness_version="${XHARNESS_VERSION:-11.0.0-prerelease.26224.1}"
+
+npm install --global "firebase-tools@${firebase_tools_version}"
+dotnet tool install --global Microsoft.DotNet.XHarness.CLI \
+  --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json \
+  --version "${xharness_version}"

--- a/scripts/run-integration-emulators.sh
+++ b/scripts/run-integration-emulators.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 android|ios" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+platform="$1"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+project_id="${FIREBASE_PROJECT_ID:-demo-pluginfirebase-integrationtests}"
+emulators="${FIREBASE_EMULATORS:-auth,firestore,functions,storage}"
+cloud_functions_dir="${repo_root}/tests/cloud-functions"
+
+export PATH="${PATH}:${HOME}/.dotnet/tools"
+export FUNCTIONS_DISCOVERY_TIMEOUT="${FUNCTIONS_DISCOVERY_TIMEOUT:-30}"
+
+quote() {
+  printf '%q' "$1"
+}
+
+resolve_android_metadata() {
+  if [ -z "${ANDROID_PACKAGE_ID:-}" ]; then
+    ANDROID_PACKAGE_ID="$(dotnet msbuild "${repo_root}/tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj" \
+      -getProperty:IntegrationTestsAndroidApplicationId \
+      -p:TargetFramework=net9.0-android \
+      | tr -d '\r\n')"
+  fi
+
+  if [ -z "${ANDROID_APK:-}" ]; then
+    ANDROID_APK="$(find "${repo_root}/tests/Plugin.Firebase.IntegrationTests/bin/Debug/net9.0-android" \
+      -name "${ANDROID_PACKAGE_ID}-Signed.apk" \
+      -type f \
+      -print \
+      -quit)"
+  fi
+
+  if [ -z "${ANDROID_PACKAGE_ID}" ]; then
+    echo "Could not resolve IntegrationTestsAndroidApplicationId." >&2
+    exit 1
+  fi
+
+  if [ -z "${ANDROID_APK}" ]; then
+    echo "Could not find signed Android APK for package '${ANDROID_PACKAGE_ID}'." >&2
+    exit 1
+  fi
+}
+
+run_android() {
+  resolve_android_metadata
+
+  local output_dir="${ANDROID_TEST_RESULTS_DIR:-${repo_root}/artifacts/test-results/android}"
+  local command
+  command="node scripts/seed-auth-emulator.js && "
+  command+="xharness android test "
+  command+="--timeout=00:10:00 "
+  command+="--launch-timeout=00:10:00 "
+  command+="--package-name $(quote "${ANDROID_PACKAGE_ID}") "
+  command+="--instrumentation devicerunners.xharness.maui.XHarnessInstrumentation "
+  command+="--app $(quote "${ANDROID_APK}") "
+  command+="--output-directory $(quote "${output_dir}") "
+  command+="--verbosity=Debug"
+
+  cd "${cloud_functions_dir}"
+  firebase emulators:exec --project "${project_id}" --only "${emulators}" "${command}"
+}
+
+run_ios() {
+  if [ -z "${DEVICE_ID:-}" ]; then
+    echo "DEVICE_ID must be set to an available iOS simulator UDID." >&2
+    exit 1
+  fi
+
+  local app_path="${IOS_APP_PATH:-${repo_root}/tests/Plugin.Firebase.IntegrationTests/bin/Debug/net9.0-ios/iossimulator-arm64/Plugin.Firebase.IntegrationTests.app}"
+  local output_dir="${IOS_TEST_RESULTS_DIR:-${repo_root}/artifacts/test-results/ios}"
+  local command
+  command="node scripts/seed-auth-emulator.js && "
+  command+="xharness apple test "
+  command+="--target ios-simulator-64 "
+  command+="--device $(quote "${DEVICE_ID}") "
+  command+="--timeout=00:10:00 "
+  command+="--launch-timeout=00:10:00 "
+  command+="--app $(quote "${app_path}") "
+  command+="--output-directory $(quote "${output_dir}") "
+  command+="--set-env=PLUGIN_FIREBASE_TEST_BACKEND=emulator"
+
+  cd "${cloud_functions_dir}"
+  firebase emulators:exec --project "${project_id}" --only "${emulators}" "${command}"
+}
+
+if [ "${SKIP_INTEGRATION_PREFLIGHT:-0}" != "1" ]; then
+  "${repo_root}/scripts/check-integration-environment.sh" "${platform}"
+fi
+
+case "${platform}" in
+  android)
+    run_android
+    ;;
+  ios)
+    run_ios
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/write-xunit-github-summary.rb
+++ b/scripts/write-xunit-github-summary.rb
@@ -24,6 +24,54 @@ def append_summary(lines)
   end
 end
 
+def relative_path(path)
+  Pathname.new(path).relative_path_from(Pathname.pwd).to_s
+rescue ArgumentError
+  path
+end
+
+def text_at(node, path)
+  child = REXML::XPath.first(node, path)
+  child&.text.to_s.strip
+rescue StandardError
+  ""
+end
+
+def test_name(test)
+  test.attributes["name"].to_s.empty? ? "#{test.attributes["type"]}.#{test.attributes["method"]}" : test.attributes["name"].to_s
+end
+
+def xml_files(results_directory)
+  Dir.glob(File.join(results_directory, "**", "*.xml")).sort
+rescue StandardError
+  []
+end
+
+def log_files(results_directory)
+  Dir.glob(File.join(results_directory, "**", "*")).select { |path| File.file?(path) }.sort
+rescue StandardError
+  []
+end
+
+def latest_test_breadcrumbs(results_directory)
+  breadcrumbs = []
+  log_files(results_directory).each do |file|
+    next if File.extname(file).casecmp(".xml").zero?
+
+    begin
+      File.foreach(file) do |line|
+        next unless line.include?("[TEST START]") || line.include?("[TEST END]")
+
+        breadcrumbs << "#{relative_path(file)}: #{line.strip}"
+        breadcrumbs.shift while breadcrumbs.length > 10
+      end
+    rescue StandardError
+      next
+    end
+  end
+  breadcrumbs
+end
+
 lines = ["### #{title}"]
 
 unless Dir.exist?(results_directory)
@@ -35,8 +83,9 @@ end
 
 seen_contents = {}
 assemblies = []
+tests = []
 
-Dir.glob(File.join(results_directory, "**", "*.xml")).sort.each do |result_file|
+xml_files(results_directory).each do |result_file|
   content = File.read(result_file)
   digest = Digest::SHA256.hexdigest(content)
   next if seen_contents.key?(digest)
@@ -62,11 +111,30 @@ Dir.glob(File.join(results_directory, "**", "*.xml")).sort.each do |result_file|
       time: assembly.attributes["time"].to_f
     }
   end
+
+  REXML::XPath.each(document, "//test") do |test|
+    tests << {
+      file: result_file,
+      name: test_name(test),
+      result: test.attributes["result"].to_s,
+      time: test.attributes["time"].to_f,
+      failure: text_at(test, "failure/message"),
+      skip_reason: test.attributes["reason"].to_s.empty? ? text_at(test, "reason") : test.attributes["reason"].to_s
+    }
+  end
+rescue StandardError
+  next
 end
 
 if assemblies.empty?
   lines << "No xUnit assembly summaries were found under `#{results_directory}`."
   lines << ""
+  breadcrumbs = latest_test_breadcrumbs(results_directory)
+  unless breadcrumbs.empty?
+    lines << "#### Latest Test Breadcrumbs"
+    breadcrumbs.each { |breadcrumb| lines << "- `#{breadcrumb}`" }
+    lines << ""
+  end
   append_summary(lines)
   exit 0
 end
@@ -80,11 +148,12 @@ totals = assemblies.each_with_object(Hash.new(0)) do |assembly, memo|
   memo[:time] += assembly[:time]
 end
 
-source_files = assemblies.map { |assembly| assembly[:file] }.uniq.map do |file|
-  Pathname.new(file).relative_path_from(Pathname.pwd).to_s
-rescue ArgumentError
-  file
-end
+source_files = assemblies.map { |assembly| relative_path(assembly[:file]) }.uniq
+
+failed_tests = tests.select { |test| test[:result].casecmp("Fail").zero? || !test[:failure].empty? }
+skipped_tests = tests.select { |test| test[:result].casecmp("Skip").zero? }
+slow_tests = tests.select { |test| test[:time].positive? }.sort_by { |test| -test[:time] }.first(10)
+breadcrumbs = latest_test_breadcrumbs(results_directory)
 
 lines << "| Total | Passed | Failed | Skipped | Errors | Time |"
 lines << "| ---: | ---: | ---: | ---: | ---: | ---: |"
@@ -95,5 +164,43 @@ lines << format(
 lines << ""
 lines << "Results: #{source_files.map { |file| "`#{file}`" }.join(", ")}"
 lines << ""
+
+unless failed_tests.empty?
+  lines << "#### Failed Tests"
+  lines << "| Test | Message |"
+  lines << "| --- | --- |"
+  failed_tests.first(20).each do |test|
+    message = test[:failure].lines.first.to_s.strip
+    lines << "| `#{test[:name]}` | #{message.empty? ? "-" : message} |"
+  end
+  lines << ""
+end
+
+unless skipped_tests.empty?
+  lines << "#### Skipped Tests"
+  lines << "| Test | Reason |"
+  lines << "| --- | --- |"
+  skipped_tests.first(20).each do |test|
+    reason = test[:skip_reason].empty? ? "-" : test[:skip_reason]
+    lines << "| `#{test[:name]}` | #{reason} |"
+  end
+  lines << ""
+end
+
+unless slow_tests.empty?
+  lines << "#### Slowest Tests"
+  lines << "| Test | Time |"
+  lines << "| --- | ---: |"
+  slow_tests.each do |test|
+    lines << format("| `%<name>s` | %<time>.1fs |", name: test[:name], time: test[:time])
+  end
+  lines << ""
+end
+
+unless breadcrumbs.empty?
+  lines << "#### Latest Test Breadcrumbs"
+  breadcrumbs.each { |breadcrumb| lines << "- `#{breadcrumb}`" }
+  lines << ""
+end
 
 append_summary(lines)

--- a/tests/Plugin.Firebase.IntegrationTests/CallbackProbe.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/CallbackProbe.cs
@@ -1,0 +1,50 @@
+namespace Plugin.Firebase.IntegrationTests;
+
+internal sealed class CallbackProbe<T>
+{
+    private readonly TaskCompletionSource<T> _completion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public bool IsCompleted => _completion.Task.IsCompleted;
+
+    public bool TrySetResult(T result)
+    {
+        return _completion.TrySetResult(result);
+    }
+
+    public bool TrySetException(Exception exception)
+    {
+        return _completion.TrySetException(exception);
+    }
+
+    public Task<T> WaitAsync(TimeSpan timeout, string operationName)
+    {
+        return _completion.Task.WaitForTestAsync(timeout, operationName);
+    }
+}
+
+internal sealed class EventProbe<TEventArgs> : IDisposable
+{
+    private readonly CallbackProbe<TEventArgs> _probe = new();
+    private readonly EventHandler<TEventArgs> _handler;
+    private readonly Action<EventHandler<TEventArgs>> _unsubscribe;
+
+    public EventProbe(
+        Action<EventHandler<TEventArgs>> subscribe,
+        Action<EventHandler<TEventArgs>> unsubscribe)
+    {
+        _handler = (_, args) => _probe.TrySetResult(args);
+        _unsubscribe = unsubscribe;
+        subscribe(_handler);
+    }
+
+    public Task<TEventArgs> WaitAsync(TimeSpan timeout, string operationName)
+    {
+        return _probe.WaitAsync(timeout, operationName);
+    }
+
+    public void Dispose()
+    {
+        _unsubscribe(_handler);
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/FirebaseTestHost.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/FirebaseTestHost.cs
@@ -1,0 +1,75 @@
+using Microsoft.Maui.LifecycleEvents;
+using Plugin.Firebase.AppCheck;
+using Plugin.Firebase.Auth;
+using Plugin.Firebase.Bundled.Shared;
+using Plugin.Firebase.Firestore;
+using Plugin.Firebase.Functions;
+using Plugin.Firebase.Storage;
+
+namespace Plugin.Firebase.IntegrationTests;
+
+internal static partial class FirebaseTestHost
+{
+    public static MauiAppBuilder RegisterFirebaseServices(this MauiAppBuilder builder)
+    {
+        builder.ConfigureLifecycleEvents(ConfigureFirebaseLifecycleEvents);
+        return builder;
+    }
+
+    private static partial void ConfigureFirebaseLifecycleEvents(ILifecycleBuilder events);
+
+    private static CrossFirebaseSettings CreateCrossFirebaseSettings()
+    {
+        if(IntegrationTestEnvironment.UsesEmulatorBackend) {
+            return new CrossFirebaseSettings(
+                isAuthEnabled: true,
+                isFirestoreEnabled: true,
+                isFunctionsEnabled: true,
+                isStorageEnabled: true,
+                appCheckOptions: AppCheckOptions.Disabled) {
+                IsInstallationsEnabled = true,
+                IsPerformanceMonitoringEnabled = true
+            };
+        }
+
+        return new CrossFirebaseSettings(
+            isAnalyticsEnabled: true,
+            isAuthEnabled: true,
+            isCloudMessagingEnabled: true,
+            isCrashlyticsEnabled: true,
+            isDynamicLinksEnabled: true,
+            isFirestoreEnabled: true,
+            isFunctionsEnabled: true,
+            isRemoteConfigEnabled: true,
+            isStorageEnabled: true,
+            appCheckOptions: IntegrationTestEnvironment.ShouldRunAppCheckTokenTests
+                ? AppCheckOptions.Debug
+                : AppCheckOptions.Disabled) {
+            IsInstallationsEnabled = true,
+            IsPerformanceMonitoringEnabled = true
+        };
+    }
+
+    private static void ConfigureEmulatorsIfRequested()
+    {
+        if(IntegrationTestEnvironment.ShouldUseAuthEmulator) {
+            var auth = IntegrationTestEnvironment.AuthEmulatorEndpoint;
+            CrossFirebaseAuth.Current.UseEmulator(auth.Host, auth.Port);
+        }
+
+        if(IntegrationTestEnvironment.ShouldUseFirestoreEmulator) {
+            var firestore = IntegrationTestEnvironment.FirestoreEmulatorEndpoint;
+            CrossFirebaseFirestore.Current.UseEmulator(firestore.Host, firestore.Port);
+        }
+
+        if(IntegrationTestEnvironment.ShouldUseFunctionsEmulator) {
+            var functions = IntegrationTestEnvironment.FunctionsEmulatorEndpoint;
+            CrossFirebaseFunctions.Current.UseEmulator(functions.Host, functions.Port);
+        }
+
+        if(IntegrationTestEnvironment.ShouldUseStorageEmulator) {
+            var storage = IntegrationTestEnvironment.StorageEmulatorEndpoint;
+            CrossFirebaseStorage.Current.UseEmulator(storage.Host, storage.Port);
+        }
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/IntegrationTestCoverageMetadata.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/IntegrationTestCoverageMetadata.cs
@@ -1,0 +1,69 @@
+namespace Plugin.Firebase.IntegrationTests;
+
+internal enum IntegrationTestPackage
+{
+    Analytics,
+    AppCheck,
+    Auth,
+    Bundled,
+    CloudMessaging,
+    Crashlytics,
+    Firestore,
+    Functions,
+    Installations,
+    PerformanceMonitoring,
+    RemoteConfig,
+    Storage
+}
+
+internal enum IntegrationTestBackendRequirement
+{
+    Any,
+    Emulator,
+    Real,
+    RealOptIn,
+    OptIn
+}
+
+internal enum IntegrationTestPlatformRequirement
+{
+    Any,
+    Android,
+    Ios,
+    IosDevice,
+    NonIosSimulator
+}
+
+internal interface IIntegrationTestCaseMetadata
+{
+    IntegrationTestBackendRequirement Backend { get; }
+
+    IntegrationTestPlatformRequirement Platform { get; }
+
+    string? OptIn { get; }
+}
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+internal sealed class IntegrationTestFixtureAttribute(IntegrationTestPackage package) : Attribute
+{
+    public IntegrationTestPackage Package { get; } = package;
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+internal sealed class IntegrationTestCoverageIgnoreAttribute(string reason) : Attribute
+{
+    public string Reason { get; } = reason;
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class IntegrationTestCaseAttribute(
+    IntegrationTestBackendRequirement backend = IntegrationTestBackendRequirement.Any,
+    IntegrationTestPlatformRequirement platform = IntegrationTestPlatformRequirement.Any,
+    string? optIn = null) : Attribute, IIntegrationTestCaseMetadata
+{
+    public IntegrationTestBackendRequirement Backend { get; } = backend;
+
+    public IntegrationTestPlatformRequirement Platform { get; } = platform;
+
+    public string? OptIn { get; } = optIn;
+}

--- a/tests/Plugin.Firebase.IntegrationTests/IntegrationTestData.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/IntegrationTestData.cs
@@ -1,0 +1,34 @@
+namespace Plugin.Firebase.IntegrationTests;
+
+internal static class IntegrationTestData
+{
+    public static string UniqueId(string prefix)
+    {
+        return $"{prefix}-{Guid.NewGuid():N}";
+    }
+
+    public static string UniqueEmail(string prefix)
+    {
+        return $"{UniqueId(prefix)}@test.com";
+    }
+
+    public static string UniqueFileName(string prefix, string extension)
+    {
+        return $"{UniqueId(prefix)}{extension}";
+    }
+
+    public static string GetRequiredConfigurationValue(
+        string environmentVariableName,
+        string? androidSystemPropertyName)
+    {
+        var value = IntegrationTestEnvironment.GetConfigurationValue(
+            environmentVariableName,
+            androidSystemPropertyName);
+        if(string.IsNullOrWhiteSpace(value)) {
+            throw new InvalidOperationException(
+                $"Set {environmentVariableName} to run this opt-in acceptance test.");
+        }
+
+        return value;
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/IntegrationTestDiagnostics.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/IntegrationTestDiagnostics.cs
@@ -1,0 +1,38 @@
+namespace Plugin.Firebase.IntegrationTests;
+
+internal static class IntegrationTestDiagnostics
+{
+    public static void WriteStartupConfiguration(bool useVisualRunner)
+    {
+        TestLog.Write("[INTEGRATION CONFIG] "
+            + $"backend={IntegrationTestEnvironment.Backend}; "
+            + $"runner={(useVisualRunner ? "visual" : "xharness")}; "
+            + $"platform={DeviceInfo.Platform}; "
+            + $"deviceType={DeviceInfo.DeviceType}; "
+            + $"appId={AppInfo.PackageName}; "
+            + $"authEmulator={FormatEndpoint(IntegrationTestEnvironment.AuthEmulatorEndpoint)}; "
+            + $"firestoreEmulator={FormatEndpoint(IntegrationTestEnvironment.FirestoreEmulatorEndpoint)}; "
+            + $"functionsEmulator={FormatEndpoint(IntegrationTestEnvironment.FunctionsEmulatorEndpoint)}; "
+            + $"storageEmulator={FormatEndpoint(IntegrationTestEnvironment.StorageEmulatorEndpoint)}; "
+            + $"appCheckTokenOptIn={IntegrationTestEnvironment.ShouldRunAppCheckTokenTests}; "
+            + $"fcmTokenOptIn={IsEnabled(IntegrationTestOptions.RunFcmTokenTestsEnvironmentVariableName)}; "
+            + $"fcmDeliveryOptIn={IsEnabled(IntegrationTestOptions.RunFcmDeliveryTestsEnvironmentVariableName)}; "
+            + $"crashlyticsForceCrashOptIn={IsEnabled(IntegrationTestOptions.ForceCrashlyticsCrashEnvironmentVariableName)}; "
+            + $"crashlyticsPreviousCrashOptIn={IsEnabled(IntegrationTestOptions.ExpectPreviousCrashEnvironmentVariableName)}; "
+            + $"installationsDeleteOptIn={IsEnabled(IntegrationTestOptions.RunInstallationsDeleteTestsEnvironmentVariableName)}; "
+            + "phoneAuthOptIn="
+            + IntegrationTestEnvironment.IsFeatureEnabled(
+                IntegrationTestOptions.RunPhoneAuthTestsEnvironmentVariableName,
+                IntegrationTestOptions.RunPhoneAuthTestsAndroidSystemPropertyName));
+    }
+
+    private static string FormatEndpoint(EmulatorEndpoint endpoint)
+    {
+        return $"{endpoint.Host}:{endpoint.Port}";
+    }
+
+    private static bool IsEnabled(string environmentVariableName)
+    {
+        return IntegrationTestEnvironment.IsFeatureEnabled(environmentVariableName, null);
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/IntegrationTestEnvironment.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/IntegrationTestEnvironment.cs
@@ -1,8 +1,3 @@
-using Xunit.Sdk;
-#if ANDROID
-using AndroidRuntime = Android.Runtime;
-#endif
-
 namespace Plugin.Firebase.IntegrationTests;
 
 internal enum IntegrationTestBackend
@@ -13,7 +8,7 @@ internal enum IntegrationTestBackend
 
 internal readonly record struct EmulatorEndpoint(string Host, int Port);
 
-internal static class IntegrationTestEnvironment
+internal static partial class IntegrationTestEnvironment
 {
     public const string ProjectId = "demo-pluginfirebase-integrationtests";
     public const string StorageBucket = "demo-pluginfirebase-integrationtests.appspot.com";
@@ -22,13 +17,14 @@ internal static class IntegrationTestEnvironment
     public const string GcmSenderId = "123456789012";
     public const string AndroidGoogleAppId = "1:123456789012:android:0123456789abcdef";
     public const string IosGoogleAppId = "1:123456789012:ios:0123456789abcdef";
-    public const string RunAppCheckTokenTestsEnvironmentVariableName = "PLUGIN_FIREBASE_RUN_APPCHECK_TOKEN_TESTS";
+    public const string RunAppCheckTokenTestsEnvironmentVariableName =
+        IntegrationTestOptions.RunAppCheckTokenTestsEnvironmentVariableName;
 
     public static IntegrationTestBackend Backend {
         get {
             var backend = GetConfigurationValue(
-                "PLUGIN_FIREBASE_TEST_BACKEND",
-                "debug.pluginfirebase.backend");
+                IntegrationTestOptions.BackendEnvironmentVariableName,
+                IntegrationTestOptions.BackendAndroidSystemPropertyName);
 
             if(string.IsNullOrWhiteSpace(backend)
                 || string.Equals(backend, "emulator", StringComparison.OrdinalIgnoreCase)) {
@@ -40,7 +36,7 @@ internal static class IntegrationTestEnvironment
             }
 
             throw new InvalidOperationException(
-                $"PLUGIN_FIREBASE_TEST_BACKEND must be 'emulator' or 'real', but was '{backend}'.");
+                $"{IntegrationTestOptions.BackendEnvironmentVariableName} must be 'emulator' or 'real', but was '{backend}'.");
         }
     }
 
@@ -49,62 +45,55 @@ internal static class IntegrationTestEnvironment
     public static bool UsesRealBackend => Backend == IntegrationTestBackend.Real;
 
     public static bool ShouldRunAppCheckTokenTests =>
-        Environment.GetEnvironmentVariable(RunAppCheckTokenTestsEnvironmentVariableName) == "1";
+        Environment.GetEnvironmentVariable(IntegrationTestOptions.RunAppCheckTokenTestsEnvironmentVariableName) == "1";
 
     public static bool ShouldUseAuthEmulator => UsesEmulatorBackend || IsFeatureEnabled(
-        "PLUGIN_FIREBASE_USE_AUTH_EMULATOR",
-        "debug.pluginfirebase.auth.use");
+        IntegrationTestOptions.UseAuthEmulatorEnvironmentVariableName,
+        IntegrationTestOptions.UseAuthEmulatorAndroidSystemPropertyName);
 
     public static bool ShouldUseFirestoreEmulator => UsesEmulatorBackend || IsFeatureEnabled(
-        "PLUGIN_FIREBASE_USE_FIRESTORE_EMULATOR",
-        "debug.pluginfirebase.firestore.use");
+        IntegrationTestOptions.UseFirestoreEmulatorEnvironmentVariableName,
+        IntegrationTestOptions.UseFirestoreEmulatorAndroidSystemPropertyName);
 
     public static bool ShouldUseFunctionsEmulator => UsesEmulatorBackend || IsFeatureEnabled(
-        "PLUGIN_FIREBASE_USE_FUNCTIONS_EMULATOR",
-        "debug.pluginfirebase.functions.use");
+        IntegrationTestOptions.UseFunctionsEmulatorEnvironmentVariableName,
+        IntegrationTestOptions.UseFunctionsEmulatorAndroidSystemPropertyName);
 
     public static bool ShouldUseStorageEmulator => UsesEmulatorBackend || IsFeatureEnabled(
-        "PLUGIN_FIREBASE_USE_STORAGE_EMULATOR",
-        "debug.pluginfirebase.storage.use");
+        IntegrationTestOptions.UseStorageEmulatorEnvironmentVariableName,
+        IntegrationTestOptions.UseStorageEmulatorAndroidSystemPropertyName);
 
     public static EmulatorEndpoint AuthEmulatorEndpoint => GetEmulatorEndpoint(
-        "PLUGIN_FIREBASE_AUTH_EMULATOR_HOST",
-        "debug.pluginfirebase.auth.host",
-        "PLUGIN_FIREBASE_AUTH_EMULATOR_PORT",
-        "debug.pluginfirebase.auth.port",
+        IntegrationTestOptions.AuthEmulatorHostEnvironmentVariableName,
+        IntegrationTestOptions.AuthEmulatorHostAndroidSystemPropertyName,
+        IntegrationTestOptions.AuthEmulatorPortEnvironmentVariableName,
+        IntegrationTestOptions.AuthEmulatorPortAndroidSystemPropertyName,
         9099);
 
     public static EmulatorEndpoint FirestoreEmulatorEndpoint => GetEmulatorEndpoint(
-        "PLUGIN_FIREBASE_FIRESTORE_EMULATOR_HOST",
-        "debug.pluginfirebase.firestore.host",
-        "PLUGIN_FIREBASE_FIRESTORE_EMULATOR_PORT",
-        "debug.pluginfirebase.firestore.port",
+        IntegrationTestOptions.FirestoreEmulatorHostEnvironmentVariableName,
+        IntegrationTestOptions.FirestoreEmulatorHostAndroidSystemPropertyName,
+        IntegrationTestOptions.FirestoreEmulatorPortEnvironmentVariableName,
+        IntegrationTestOptions.FirestoreEmulatorPortAndroidSystemPropertyName,
         8080);
 
     public static EmulatorEndpoint FunctionsEmulatorEndpoint => GetEmulatorEndpoint(
-        "PLUGIN_FIREBASE_FUNCTIONS_EMULATOR_HOST",
-        "debug.pluginfirebase.functions.host",
-        "PLUGIN_FIREBASE_FUNCTIONS_EMULATOR_PORT",
-        "debug.pluginfirebase.functions.port",
+        IntegrationTestOptions.FunctionsEmulatorHostEnvironmentVariableName,
+        IntegrationTestOptions.FunctionsEmulatorHostAndroidSystemPropertyName,
+        IntegrationTestOptions.FunctionsEmulatorPortEnvironmentVariableName,
+        IntegrationTestOptions.FunctionsEmulatorPortAndroidSystemPropertyName,
         5001);
 
     public static EmulatorEndpoint StorageEmulatorEndpoint => GetEmulatorEndpoint(
-        "PLUGIN_FIREBASE_STORAGE_EMULATOR_HOST",
-        "debug.pluginfirebase.storage.host",
-        "PLUGIN_FIREBASE_STORAGE_EMULATOR_PORT",
-        "debug.pluginfirebase.storage.port",
+        IntegrationTestOptions.StorageEmulatorHostEnvironmentVariableName,
+        IntegrationTestOptions.StorageEmulatorHostAndroidSystemPropertyName,
+        IntegrationTestOptions.StorageEmulatorPortEnvironmentVariableName,
+        IntegrationTestOptions.StorageEmulatorPortAndroidSystemPropertyName,
         9199);
-
-    public static void SkipIfEmulatorBackend(string reason)
-    {
-        if(UsesEmulatorBackend) {
-            throw SkipException.ForSkip(reason);
-        }
-    }
 
     public static bool IsFeatureEnabled(
         string environmentVariableName,
-        string androidSystemPropertyName)
+        string? androidSystemPropertyName)
     {
         return string.Equals(
             GetConfigurationValue(environmentVariableName, androidSystemPropertyName),
@@ -112,20 +101,14 @@ internal static class IntegrationTestEnvironment
             StringComparison.Ordinal);
     }
 
-    public static string GetConfigurationValue(
+    public static string? GetConfigurationValue(
         string environmentVariableName,
-        string androidSystemPropertyName)
+        string? androidSystemPropertyName)
     {
         var environmentVariableValue = Environment.GetEnvironmentVariable(environmentVariableName);
-        if(!string.IsNullOrWhiteSpace(environmentVariableValue)) {
-            return environmentVariableValue;
-        }
-
-#if ANDROID
-        return GetAndroidSystemProperty(androidSystemPropertyName);
-#else
-        return null;
-#endif
+        return !string.IsNullOrWhiteSpace(environmentVariableValue)
+            ? environmentVariableValue
+            : GetPlatformConfigurationValue(androidSystemPropertyName);
     }
 
     private static EmulatorEndpoint GetEmulatorEndpoint(
@@ -171,37 +154,5 @@ internal static class IntegrationTestEnvironment
         return port;
     }
 
-#if ANDROID
-    private static string GetAndroidSystemProperty(string propertyName)
-    {
-        IntPtr? propertyValuePointer = null;
-
-        try {
-            var systemPropertiesClass = AndroidRuntime.JNIEnv.FindClass("android/os/SystemProperties");
-            var getMethodId = AndroidRuntime.JNIEnv.GetStaticMethodID(
-                systemPropertiesClass,
-                "get",
-                "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
-
-            using var propertyNameValue = new Java.Lang.String(propertyName);
-            using var defaultValue = new Java.Lang.String(string.Empty);
-            propertyValuePointer = AndroidRuntime.JNIEnv.CallStaticObjectMethod(
-                systemPropertiesClass,
-                getMethodId,
-                new AndroidRuntime.JValue(propertyNameValue),
-                new AndroidRuntime.JValue(defaultValue));
-
-            return AndroidRuntime.JNIEnv.GetString(
-                propertyValuePointer.Value,
-                AndroidRuntime.JniHandleOwnership.DoNotTransfer);
-        } catch {
-            return null;
-        }
-        finally {
-            if(propertyValuePointer.HasValue && propertyValuePointer.Value != IntPtr.Zero) {
-                AndroidRuntime.JNIEnv.DeleteLocalRef(propertyValuePointer.Value);
-            }
-        }
-    }
-#endif
+    private static partial string? GetPlatformConfigurationValue(string? androidSystemPropertyName);
 }

--- a/tests/Plugin.Firebase.IntegrationTests/IntegrationTestOptions.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/IntegrationTestOptions.cs
@@ -1,0 +1,57 @@
+namespace Plugin.Firebase.IntegrationTests;
+
+internal static class IntegrationTestOptions
+{
+    public const string BackendEnvironmentVariableName = "PLUGIN_FIREBASE_TEST_BACKEND";
+    public const string BackendAndroidSystemPropertyName = "debug.pluginfirebase.backend";
+
+    public const string UseVisualRunnerEnvironmentVariableName = "PLUGIN_FIREBASE_USE_VISUAL_RUNNER";
+    public const string UseVisualRunnerAndroidSystemPropertyName = "debug.pluginfirebase.visual.use";
+
+    public const string RunAppCheckTokenTestsEnvironmentVariableName = "PLUGIN_FIREBASE_RUN_APPCHECK_TOKEN_TESTS";
+    public const string RunFcmTokenTestsEnvironmentVariableName = "PLUGIN_FIREBASE_RUN_FCM_TOKEN_TESTS";
+    public const string RunFcmDeliveryTestsEnvironmentVariableName = "PLUGIN_FIREBASE_RUN_FCM_DELIVERY_TESTS";
+    public const string ForceCrashlyticsCrashEnvironmentVariableName = "PLUGIN_FIREBASE_FORCE_CRASHLYTICS_CRASH";
+    public const string ExpectPreviousCrashEnvironmentVariableName = "PLUGIN_FIREBASE_EXPECT_PREVIOUS_CRASH";
+    public const string RunInstallationsDeleteTestsEnvironmentVariableName =
+        "PLUGIN_FIREBASE_RUN_INSTALLATIONS_DELETE_TESTS";
+
+    public const string RunPhoneAuthTestsEnvironmentVariableName = "PLUGIN_FIREBASE_RUN_PHONE_AUTH_TESTS";
+    public const string RunPhoneAuthTestsAndroidSystemPropertyName = "debug.pluginfirebase.phone.run";
+    public const string PhoneAuthNumberEnvironmentVariableName = "PLUGIN_FIREBASE_PHONE_AUTH_NUMBER";
+    public const string PhoneAuthNumberAndroidSystemPropertyName = "debug.pluginfirebase.phone.number";
+    public const string PhoneAuthCodeEnvironmentVariableName = "PLUGIN_FIREBASE_PHONE_AUTH_CODE";
+    public const string PhoneAuthCodeAndroidSystemPropertyName = "debug.pluginfirebase.phone.code";
+    public const string PhoneAuthVerificationIdEnvironmentVariableName =
+        "PLUGIN_FIREBASE_PHONE_AUTH_VERIFICATION_ID";
+    public const string PhoneAuthVerificationIdAndroidSystemPropertyName =
+        "debug.pluginfirebase.phone.verification_id";
+
+    public const string UseAuthEmulatorEnvironmentVariableName = "PLUGIN_FIREBASE_USE_AUTH_EMULATOR";
+    public const string UseAuthEmulatorAndroidSystemPropertyName = "debug.pluginfirebase.auth.use";
+    public const string AuthEmulatorHostEnvironmentVariableName = "PLUGIN_FIREBASE_AUTH_EMULATOR_HOST";
+    public const string AuthEmulatorHostAndroidSystemPropertyName = "debug.pluginfirebase.auth.host";
+    public const string AuthEmulatorPortEnvironmentVariableName = "PLUGIN_FIREBASE_AUTH_EMULATOR_PORT";
+    public const string AuthEmulatorPortAndroidSystemPropertyName = "debug.pluginfirebase.auth.port";
+
+    public const string UseFirestoreEmulatorEnvironmentVariableName = "PLUGIN_FIREBASE_USE_FIRESTORE_EMULATOR";
+    public const string UseFirestoreEmulatorAndroidSystemPropertyName = "debug.pluginfirebase.firestore.use";
+    public const string FirestoreEmulatorHostEnvironmentVariableName = "PLUGIN_FIREBASE_FIRESTORE_EMULATOR_HOST";
+    public const string FirestoreEmulatorHostAndroidSystemPropertyName = "debug.pluginfirebase.firestore.host";
+    public const string FirestoreEmulatorPortEnvironmentVariableName = "PLUGIN_FIREBASE_FIRESTORE_EMULATOR_PORT";
+    public const string FirestoreEmulatorPortAndroidSystemPropertyName = "debug.pluginfirebase.firestore.port";
+
+    public const string UseFunctionsEmulatorEnvironmentVariableName = "PLUGIN_FIREBASE_USE_FUNCTIONS_EMULATOR";
+    public const string UseFunctionsEmulatorAndroidSystemPropertyName = "debug.pluginfirebase.functions.use";
+    public const string FunctionsEmulatorHostEnvironmentVariableName = "PLUGIN_FIREBASE_FUNCTIONS_EMULATOR_HOST";
+    public const string FunctionsEmulatorHostAndroidSystemPropertyName = "debug.pluginfirebase.functions.host";
+    public const string FunctionsEmulatorPortEnvironmentVariableName = "PLUGIN_FIREBASE_FUNCTIONS_EMULATOR_PORT";
+    public const string FunctionsEmulatorPortAndroidSystemPropertyName = "debug.pluginfirebase.functions.port";
+
+    public const string UseStorageEmulatorEnvironmentVariableName = "PLUGIN_FIREBASE_USE_STORAGE_EMULATOR";
+    public const string UseStorageEmulatorAndroidSystemPropertyName = "debug.pluginfirebase.storage.use";
+    public const string StorageEmulatorHostEnvironmentVariableName = "PLUGIN_FIREBASE_STORAGE_EMULATOR_HOST";
+    public const string StorageEmulatorHostAndroidSystemPropertyName = "debug.pluginfirebase.storage.host";
+    public const string StorageEmulatorPortEnvironmentVariableName = "PLUGIN_FIREBASE_STORAGE_EMULATOR_PORT";
+    public const string StorageEmulatorPortAndroidSystemPropertyName = "debug.pluginfirebase.storage.port";
+}

--- a/tests/Plugin.Firebase.IntegrationTests/IntegrationTestSkipPolicy.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/IntegrationTestSkipPolicy.cs
@@ -1,0 +1,101 @@
+namespace Plugin.Firebase.IntegrationTests;
+
+internal static class IntegrationTestSkipReasons
+{
+    public const string EmulatorBackendRequired =
+        "This test requires Firebase emulators. Set PLUGIN_FIREBASE_TEST_BACKEND=emulator to run it.";
+    public const string RealBackendRequired =
+        "This test requires a real Firebase project. Set PLUGIN_FIREBASE_TEST_BACKEND=real to run it.";
+    public const string AndroidRequired = "This test only applies to Android.";
+    public const string IosRequired = "This test only applies to iOS.";
+    public const string IosDeviceRequired = "This test requires a real iOS device with APNs configured.";
+    public const string IosSimulatorUnsupported = "This test does not run on the iOS simulator.";
+}
+
+internal static class IntegrationTestSkipPolicy
+{
+    public static string? RequireEmulatorBackend()
+    {
+        return IntegrationTestEnvironment.UsesRealBackend
+            ? IntegrationTestSkipReasons.EmulatorBackendRequired
+            : null;
+    }
+
+    public static string? RequireRealBackend()
+    {
+        return IntegrationTestEnvironment.UsesEmulatorBackend
+            ? IntegrationTestSkipReasons.RealBackendRequired
+            : null;
+    }
+
+    public static string? RequireRealBackendOptIn(
+        string environmentVariableName,
+        string? androidSystemPropertyName,
+        bool skipIosSimulator)
+    {
+        return RequireRealBackend()
+            ?? RequireIosDeviceWhen(skipIosSimulator)
+            ?? RequireOptIn(environmentVariableName, androidSystemPropertyName, realBackend: true);
+    }
+
+    public static string? RequireOptIn(
+        string environmentVariableName,
+        string? androidSystemPropertyName)
+    {
+        return RequireOptIn(environmentVariableName, androidSystemPropertyName, realBackend: false);
+    }
+
+    public static string? RequireAndroid()
+    {
+        return OperatingSystem.IsAndroid()
+            ? null
+            : IntegrationTestSkipReasons.AndroidRequired;
+    }
+
+    public static string? RequireIos()
+    {
+        return OperatingSystem.IsIOS()
+            ? null
+            : IntegrationTestSkipReasons.IosRequired;
+    }
+
+    public static string? RequireIosDevice()
+    {
+        return RequireIos() ?? RequireIosDeviceWhen(skipIosSimulator: true);
+    }
+
+    public static string? RequireNonIosSimulator()
+    {
+        return IsIosSimulator()
+            ? IntegrationTestSkipReasons.IosSimulatorUnsupported
+            : null;
+    }
+
+    private static string? RequireIosDeviceWhen(bool skipIosSimulator)
+    {
+        return skipIosSimulator && IsIosSimulator()
+            ? IntegrationTestSkipReasons.IosDeviceRequired
+            : null;
+    }
+
+    private static string? RequireOptIn(
+        string environmentVariableName,
+        string? androidSystemPropertyName,
+        bool realBackend)
+    {
+        if(IntegrationTestEnvironment.IsFeatureEnabled(environmentVariableName, androidSystemPropertyName)) {
+            return null;
+        }
+
+        var backendScope = realBackend
+            ? " opt-in real Firebase"
+            : " opt-in integration";
+        return $"Set {environmentVariableName}=1 to run this{backendScope} test.";
+    }
+
+    private static bool IsIosSimulator()
+    {
+        return OperatingSystem.IsIOS()
+            && DeviceInfo.DeviceType == DeviceType.Virtual;
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/IntegrationTestTasks.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/IntegrationTestTasks.cs
@@ -1,0 +1,59 @@
+namespace Plugin.Firebase.IntegrationTests;
+
+internal static class IntegrationTestTasks
+{
+    public static async Task<T> WaitForTestAsync<T>(
+        this Task<T> task,
+        TimeSpan timeout,
+        string operationName)
+    {
+        try {
+            return await task.WaitAsync(timeout);
+        } catch(TimeoutException e) {
+            throw new TimeoutException(
+                $"Timed out waiting for {operationName} after {timeout}.",
+                e);
+        }
+    }
+
+    public static async Task WaitForTestAsync(
+        this Task task,
+        TimeSpan timeout,
+        string operationName)
+    {
+        try {
+            await task.WaitAsync(timeout);
+        } catch(TimeoutException e) {
+            throw new TimeoutException(
+                $"Timed out waiting for {operationName} after {timeout}.",
+                e);
+        }
+    }
+
+    public static async Task EventuallyAsync(
+        Action assertion,
+        TimeSpan timeout,
+        TimeSpan? pollInterval = null)
+    {
+        var interval = pollInterval ?? IntegrationTestTimeouts.PollInterval;
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+
+        while(DateTimeOffset.UtcNow < deadline) {
+            try {
+                assertion();
+                return;
+            } catch(Exception e) when(IsAssertionException(e)) {
+                await Task.Delay(interval);
+            }
+        }
+
+        assertion();
+    }
+
+    private static bool IsAssertionException(Exception exception)
+    {
+        var type = exception.GetType();
+        return type.Namespace == "Xunit.Sdk"
+            || type.FullName?.StartsWith("Xunit.Sdk.", StringComparison.Ordinal) == true;
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/IntegrationTestTimeouts.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/IntegrationTestTimeouts.cs
@@ -1,0 +1,13 @@
+namespace Plugin.Firebase.IntegrationTests;
+
+internal static class IntegrationTestTimeouts
+{
+    public static readonly TimeSpan ShortCallback = TimeSpan.FromSeconds(5);
+    public static readonly TimeSpan Callback = TimeSpan.FromSeconds(10);
+    public static readonly TimeSpan LongCallback = TimeSpan.FromSeconds(20);
+    public static readonly TimeSpan Cleanup = TimeSpan.FromSeconds(15);
+    public static readonly TimeSpan FcmDelivery = TimeSpan.FromMinutes(2);
+    public static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
+
+    public static long OneMillisecondTicks => TimeSpan.FromMilliseconds(1).Ticks;
+}

--- a/tests/Plugin.Firebase.IntegrationTests/MauiProgram.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/MauiProgram.cs
@@ -1,53 +1,31 @@
-using Microsoft.Maui.LifecycleEvents;
-using Plugin.Firebase.AppCheck;
-using Plugin.Firebase.Auth;
-using Plugin.Firebase.Bundled.Shared;
-using Plugin.Firebase.Firestore;
-using Plugin.Firebase.Functions;
-using Plugin.Firebase.IntegrationTests;
-using Plugin.Firebase.Storage;
-#if IOS
-using Foundation;
-using NativeFirebaseOptions = Firebase.Core.Options;
-using PlatformCrossFirebase = Plugin.Firebase.Bundled.Platforms.iOS.CrossFirebase;
-#elif ANDROID
-using NativeFirebaseApp = global::Firebase.FirebaseApp;
-using NativeFirebaseOptions = Firebase.FirebaseOptions;
-using PlatformCrossFirebase = Plugin.Firebase.Bundled.Platforms.Android.CrossFirebase;
-#endif
 using DeviceRunners.UITesting;
 using DeviceRunners.VisualRunners;
 using DeviceRunners.XHarness;
 
-namespace Plugin.Firebase.IntegrationTests2;
+namespace Plugin.Firebase.IntegrationTests;
 
 public static class MauiProgram
 {
     public static MauiApp CreateMauiApp()
     {
         var useVisualRunner = IntegrationTestEnvironment.IsFeatureEnabled(
-            "PLUGIN_FIREBASE_USE_VISUAL_RUNNER",
-            "debug.pluginfirebase.visual.use");
+            IntegrationTestOptions.UseVisualRunnerEnvironmentVariableName,
+            IntegrationTestOptions.UseVisualRunnerAndroidSystemPropertyName);
+        IntegrationTestDiagnostics.WriteStartupConfiguration(useVisualRunner);
+
         var builder = MauiApp
             .CreateBuilder()
             .ConfigureUITesting()
             .UseVisualTestRunner(conf => {
-                if(useVisualRunner) {
-                    conf.SetTestRunnerUsage(VisualTestRunnerUsage.Always);
-                } else {
-                    conf.SetTestRunnerUsage(VisualTestRunnerUsage.Never);
-                }
+                conf.SetTestRunnerUsage(useVisualRunner ? VisualTestRunnerUsage.Always : VisualTestRunnerUsage.Never);
 
                 conf.AddConsoleResultChannel()
                     .AddTestAssembly(typeof(MauiProgram).Assembly)
                     .AddXunit();
             })
             .UseXHarnessTestRunner(conf => {
-                if(useVisualRunner) {
-                    conf.SetTestRunnerUsage(XHarnessTestRunnerUsage.Never);
-                } else {
-                    conf.SetTestRunnerUsage(XHarnessTestRunnerUsage.Always);
-                }
+                conf.SetTestRunnerUsage(
+                    useVisualRunner ? XHarnessTestRunnerUsage.Never : XHarnessTestRunnerUsage.Always);
 
                 conf.AddTestAssembly(typeof(MauiProgram).Assembly)
                     .AddXunit();
@@ -56,162 +34,4 @@ public static class MauiProgram
 
         return builder.Build();
     }
-
-    private static MauiAppBuilder RegisterFirebaseServices(this MauiAppBuilder builder)
-    {
-        builder.ConfigureLifecycleEvents(events => {
-#if IOS
-            events.AddiOS(iOS => iOS.WillFinishLaunching((_,__) => {
-                if(IntegrationTestEnvironment.UsesRealBackend) {
-                    EnsureFirebaseConfigPresent();
-                    PlatformCrossFirebase.Initialize(CreateCrossFirebaseSettings());
-                } else {
-                    PlatformCrossFirebase.Initialize(
-                        CreateCrossFirebaseSettings(),
-                        CreateEmulatorFirebaseOptions());
-                }
-                ConfigureEmulatorsIfRequested();
-                return false;
-            }));
-#elif ANDROID
-            events.AddAndroid(android => android.OnCreate((activity, _) => {
-                if(IntegrationTestEnvironment.UsesEmulatorBackend) {
-                    DeleteDefaultFirebaseAppIfInitialized();
-                }
-
-                PlatformCrossFirebase.Initialize(
-                    activity,
-                    () => Platform.CurrentActivity,
-                    CreateCrossFirebaseSettings(),
-                    IntegrationTestEnvironment.UsesEmulatorBackend ? CreateEmulatorFirebaseOptions() : null);
-                ConfigureEmulatorsIfRequested();
-            }));
-#endif
-        });
-        return builder;
-    }
-
-#if IOS
-    private static void EnsureFirebaseConfigPresent()
-    {
-        var bundleIdentifier = NSBundle.MainBundle.BundleIdentifier ?? "<unknown>";
-        var configPath = NSBundle.MainBundle.PathForResource("GoogleService-Info", "plist");
-
-        if(configPath == null) {
-            throw new InvalidOperationException(
-                "GoogleService-Info.plist was not bundled into the integration test app. "
-                    + "Place the file at tests/Plugin.Firebase.IntegrationTests/GoogleService-Info.plist "
-                    + $"and make sure it was generated for the bundle identifier '{bundleIdentifier}'."
-            );
-        }
-
-        var config = NSMutableDictionary.FromFile(configPath);
-        var configuredBundleIdentifier = config?.ObjectForKey(new NSString("BUNDLE_ID"))?.ToString();
-        if(string.IsNullOrWhiteSpace(configuredBundleIdentifier)) {
-            throw new InvalidOperationException(
-                "GoogleService-Info.plist is missing the BUNDLE_ID entry. "
-                    + "Regenerate the plist from Firebase and bundle it into the integration test app."
-            );
-        }
-
-        if(!string.Equals(configuredBundleIdentifier, bundleIdentifier, StringComparison.Ordinal)) {
-            throw new InvalidOperationException(
-                $"GoogleService-Info.plist was generated for '{configuredBundleIdentifier}', "
-                    + $"but the integration test app is running as '{bundleIdentifier}'. "
-                    + "Update the app bundle identifier or replace the plist so they match."
-            );
-        }
-    }
-#endif
-
-    private static CrossFirebaseSettings CreateCrossFirebaseSettings()
-    {
-        if(IntegrationTestEnvironment.UsesEmulatorBackend) {
-            return new CrossFirebaseSettings(
-                isAuthEnabled: true,
-                isFirestoreEnabled: true,
-                isFunctionsEnabled: true,
-                isStorageEnabled: true,
-                appCheckOptions: AppCheckOptions.Disabled) {
-                IsInstallationsEnabled = true,
-                IsPerformanceMonitoringEnabled = true
-            };
-        }
-
-        return new CrossFirebaseSettings(
-            isAnalyticsEnabled: true,
-            isAuthEnabled: true,
-            isCloudMessagingEnabled: true,
-            isCrashlyticsEnabled: true,
-            isDynamicLinksEnabled: true,
-            isFirestoreEnabled: true,
-            isFunctionsEnabled: true,
-            isRemoteConfigEnabled: true,
-            isStorageEnabled: true,
-            appCheckOptions: IntegrationTestEnvironment.ShouldRunAppCheckTokenTests
-                ? AppCheckOptions.Debug
-                : AppCheckOptions.Disabled) {
-            IsInstallationsEnabled = true,
-            IsPerformanceMonitoringEnabled = true
-        };
-    }
-
-    private static void ConfigureEmulatorsIfRequested()
-    {
-        if(IntegrationTestEnvironment.ShouldUseAuthEmulator) {
-            var auth = IntegrationTestEnvironment.AuthEmulatorEndpoint;
-            CrossFirebaseAuth.Current.UseEmulator(auth.Host, auth.Port);
-        }
-
-        if(IntegrationTestEnvironment.ShouldUseFirestoreEmulator) {
-            var firestore = IntegrationTestEnvironment.FirestoreEmulatorEndpoint;
-            CrossFirebaseFirestore.Current.UseEmulator(firestore.Host, firestore.Port);
-        }
-
-        if(IntegrationTestEnvironment.ShouldUseFunctionsEmulator) {
-            var functions = IntegrationTestEnvironment.FunctionsEmulatorEndpoint;
-            CrossFirebaseFunctions.Current.UseEmulator(functions.Host, functions.Port);
-        }
-
-        if(IntegrationTestEnvironment.ShouldUseStorageEmulator) {
-            var storage = IntegrationTestEnvironment.StorageEmulatorEndpoint;
-            CrossFirebaseStorage.Current.UseEmulator(storage.Host, storage.Port);
-        }
-    }
-
-#if IOS
-    private static NativeFirebaseOptions CreateEmulatorFirebaseOptions()
-    {
-        return new NativeFirebaseOptions(
-            IntegrationTestEnvironment.IosGoogleAppId,
-            IntegrationTestEnvironment.GcmSenderId) {
-            ApiKey = IntegrationTestEnvironment.ApiKey,
-            BundleId = NSBundle.MainBundle.BundleIdentifier,
-            DatabaseUrl = IntegrationTestEnvironment.DatabaseUrl,
-            ProjectId = IntegrationTestEnvironment.ProjectId,
-            StorageBucket = IntegrationTestEnvironment.StorageBucket
-        };
-    }
-#elif ANDROID
-    private static void DeleteDefaultFirebaseAppIfInitialized()
-    {
-        try {
-            NativeFirebaseApp.Instance.Delete();
-        } catch(Java.Lang.IllegalStateException) {
-            // FirebaseInitProvider only creates a default app when google-services.json is present.
-        }
-    }
-
-    private static NativeFirebaseOptions CreateEmulatorFirebaseOptions()
-    {
-        return new NativeFirebaseOptions.Builder()
-            .SetApiKey(IntegrationTestEnvironment.ApiKey)
-            .SetApplicationId(IntegrationTestEnvironment.AndroidGoogleAppId)
-            .SetDatabaseUrl(IntegrationTestEnvironment.DatabaseUrl)
-            .SetGcmSenderId(IntegrationTestEnvironment.GcmSenderId)
-            .SetProjectId(IntegrationTestEnvironment.ProjectId)
-            .SetStorageBucket(IntegrationTestEnvironment.StorageBucket)
-            .Build();
-    }
-#endif
 }

--- a/tests/Plugin.Firebase.IntegrationTests/Platforms/Android/FirebaseTestHost.android.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Platforms/Android/FirebaseTestHost.android.cs
@@ -1,0 +1,46 @@
+using Microsoft.Maui.LifecycleEvents;
+using NativeFirebaseApp = Firebase.FirebaseApp;
+using NativeFirebaseOptions = Firebase.FirebaseOptions;
+using PlatformCrossFirebase = Plugin.Firebase.Bundled.Platforms.Android.CrossFirebase;
+
+namespace Plugin.Firebase.IntegrationTests;
+
+internal static partial class FirebaseTestHost
+{
+    private static partial void ConfigureFirebaseLifecycleEvents(ILifecycleBuilder events)
+    {
+        events.AddAndroid(android => android.OnCreate((activity, _) => {
+            if(IntegrationTestEnvironment.UsesEmulatorBackend) {
+                DeleteDefaultFirebaseAppIfInitialized();
+            }
+
+            PlatformCrossFirebase.Initialize(
+                activity,
+                () => Platform.CurrentActivity!,
+                CreateCrossFirebaseSettings(),
+                IntegrationTestEnvironment.UsesEmulatorBackend ? CreateEmulatorFirebaseOptions() : null);
+            ConfigureEmulatorsIfRequested();
+        }));
+    }
+
+    private static void DeleteDefaultFirebaseAppIfInitialized()
+    {
+        try {
+            NativeFirebaseApp.Instance.Delete();
+        } catch(Java.Lang.IllegalStateException) {
+            // FirebaseInitProvider only creates a default app when google-services.json is present.
+        }
+    }
+
+    private static NativeFirebaseOptions CreateEmulatorFirebaseOptions()
+    {
+        return new NativeFirebaseOptions.Builder()
+            .SetApiKey(IntegrationTestEnvironment.ApiKey)
+            .SetApplicationId(IntegrationTestEnvironment.AndroidGoogleAppId)
+            .SetDatabaseUrl(IntegrationTestEnvironment.DatabaseUrl)
+            .SetGcmSenderId(IntegrationTestEnvironment.GcmSenderId)
+            .SetProjectId(IntegrationTestEnvironment.ProjectId)
+            .SetStorageBucket(IntegrationTestEnvironment.StorageBucket)
+            .Build();
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/Platforms/Android/IntegrationTestEnvironment.android.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Platforms/Android/IntegrationTestEnvironment.android.cs
@@ -1,0 +1,45 @@
+using AndroidRuntime = Android.Runtime;
+
+namespace Plugin.Firebase.IntegrationTests;
+
+internal static partial class IntegrationTestEnvironment
+{
+    private static partial string? GetPlatformConfigurationValue(string? androidSystemPropertyName)
+    {
+        return string.IsNullOrWhiteSpace(androidSystemPropertyName)
+            ? null
+            : GetAndroidSystemProperty(androidSystemPropertyName);
+    }
+
+    private static string? GetAndroidSystemProperty(string propertyName)
+    {
+        IntPtr? propertyValuePointer = null;
+
+        try {
+            var systemPropertiesClass = AndroidRuntime.JNIEnv.FindClass("android/os/SystemProperties");
+            var getMethodId = AndroidRuntime.JNIEnv.GetStaticMethodID(
+                systemPropertiesClass,
+                "get",
+                "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+
+            using var propertyNameValue = new Java.Lang.String(propertyName);
+            using var defaultValue = new Java.Lang.String(string.Empty);
+            propertyValuePointer = AndroidRuntime.JNIEnv.CallStaticObjectMethod(
+                systemPropertiesClass,
+                getMethodId,
+                new AndroidRuntime.JValue(propertyNameValue),
+                new AndroidRuntime.JValue(defaultValue));
+
+            return AndroidRuntime.JNIEnv.GetString(
+                propertyValuePointer.Value,
+                AndroidRuntime.JniHandleOwnership.DoNotTransfer);
+        } catch {
+            return null;
+        }
+        finally {
+            if(propertyValuePointer.HasValue && propertyValuePointer.Value != IntPtr.Zero) {
+                AndroidRuntime.JNIEnv.DeleteLocalRef(propertyValuePointer.Value);
+            }
+        }
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/Platforms/Android/MainActivity.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Platforms/Android/MainActivity.cs
@@ -1,9 +1,44 @@
 using Android.App;
+using Android.Content;
 using Android.Content.PM;
+using Android.OS;
+using Plugin.Firebase.CloudMessaging;
 
-namespace Plugin.Firebase.IntegrationTests2;
+namespace Plugin.Firebase.IntegrationTests;
 
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+        CreateNotificationChannel();
+        var intent = Intent;
+        if(intent != null) {
+            FirebaseCloudMessagingImplementation.OnNewIntent(intent);
+        }
+    }
+
+    protected override void OnNewIntent(Intent? intent)
+    {
+        base.OnNewIntent(intent);
+        if(intent != null) {
+            FirebaseCloudMessagingImplementation.OnNewIntent(intent);
+        }
+    }
+
+    private void CreateNotificationChannel()
+    {
+        if(!OperatingSystem.IsAndroidVersionAtLeast(26)) {
+            return;
+        }
+
+        var channelId = $"{PackageName}.general";
+        if(GetSystemService(NotificationService) is not NotificationManager notificationManager) {
+            throw new InvalidOperationException("Unable to get NotificationManager.");
+        }
+        var channel = new NotificationChannel(channelId, "General", NotificationImportance.Default);
+        notificationManager.CreateNotificationChannel(channel);
+        FirebaseCloudMessagingImplementation.ChannelId = channelId;
+    }
 }

--- a/tests/Plugin.Firebase.IntegrationTests/Platforms/Android/MainApplication.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Platforms/Android/MainApplication.cs
@@ -1,15 +1,10 @@
 using Android.App;
 using Android.Runtime;
 
-namespace Plugin.Firebase.IntegrationTests2;
+namespace Plugin.Firebase.IntegrationTests;
 
 [Application]
-public class MainApplication : MauiApplication
+public class MainApplication(IntPtr handle, JniHandleOwnership ownership) : MauiApplication(handle, ownership)
 {
-    public MainApplication(IntPtr handle, JniHandleOwnership ownership)
-        : base(handle, ownership)
-    {
-    }
-
     protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }

--- a/tests/Plugin.Firebase.IntegrationTests/Platforms/iOS/AppDelegate.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Platforms/iOS/AppDelegate.cs
@@ -1,6 +1,6 @@
 using Foundation;
 
-namespace Plugin.Firebase.IntegrationTests2;
+namespace Plugin.Firebase.IntegrationTests;
 
 [Register("AppDelegate")]
 public class AppDelegate : MauiUIApplicationDelegate

--- a/tests/Plugin.Firebase.IntegrationTests/Platforms/iOS/FirebaseTestHost.ios.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Platforms/iOS/FirebaseTestHost.ios.cs
@@ -1,0 +1,102 @@
+using Foundation;
+using Microsoft.Maui.LifecycleEvents;
+using NativeFirebaseOptions = Firebase.Core.Options;
+
+namespace Plugin.Firebase.IntegrationTests;
+
+internal static partial class FirebaseTestHost
+{
+    private static partial void ConfigureFirebaseLifecycleEvents(ILifecycleBuilder events)
+    {
+        events.AddiOS(iOS => iOS.WillFinishLaunching((_, _) => {
+            if(IntegrationTestEnvironment.UsesRealBackend) {
+                EnsureFirebaseConfigPresent();
+                InitializeBundledFirebase(CreateCrossFirebaseSettings());
+            } else {
+                InitializeBundledFirebase(
+                    CreateCrossFirebaseSettings(),
+                    CreateEmulatorFirebaseOptions());
+            }
+
+            ConfigureEmulatorsIfRequested();
+            return false;
+        }));
+    }
+
+    [System.Diagnostics.CodeAnalysis.DynamicDependency(
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods,
+        "Plugin.Firebase.Bundled.Platforms.iOS.CrossFirebase",
+        "Plugin.Firebase")]
+    private static void InitializeBundledFirebase(
+        Plugin.Firebase.Bundled.Shared.CrossFirebaseSettings settings,
+        NativeFirebaseOptions? firebaseOptions = null)
+    {
+        const string initializerTypeName = "Plugin.Firebase.Bundled.Platforms.iOS.CrossFirebase";
+
+        var initializerType = typeof(Plugin.Firebase.Bundled.Shared.CrossFirebaseSettings)
+            .Assembly
+            .GetType(initializerTypeName, throwOnError: true);
+        if(initializerType == null) {
+            throw new InvalidOperationException($"Unable to find type '{initializerTypeName}'.");
+        }
+        var initialize = initializerType.GetMethod(
+            "Initialize",
+            [
+                typeof(Plugin.Firebase.Bundled.Shared.CrossFirebaseSettings),
+                typeof(NativeFirebaseOptions),
+                typeof(string)
+            ]);
+
+        if(initialize == null) {
+            throw new MissingMethodException(
+                initializerTypeName,
+                "Initialize(CrossFirebaseSettings, Firebase.Core.Options, string)");
+        }
+
+        initialize.Invoke(null, [settings, firebaseOptions, null]);
+    }
+
+    private static void EnsureFirebaseConfigPresent()
+    {
+        var bundleIdentifier = NSBundle.MainBundle.BundleIdentifier;
+        var configPath = NSBundle.MainBundle.PathForResource("GoogleService-Info", "plist");
+
+        if(configPath == null) {
+            throw new InvalidOperationException(
+                "GoogleService-Info.plist was not bundled into the integration test app. "
+                    + "Place the file at tests/Plugin.Firebase.IntegrationTests/GoogleService-Info.plist "
+                    + $"and make sure it was generated for the bundle identifier '{bundleIdentifier}'."
+            );
+        }
+
+        var config = NSMutableDictionary.FromFile(configPath);
+        var configuredBundleIdentifier = config.ObjectForKey(new NSString("BUNDLE_ID"))?.ToString();
+        if(string.IsNullOrWhiteSpace(configuredBundleIdentifier)) {
+            throw new InvalidOperationException(
+                "GoogleService-Info.plist is missing the BUNDLE_ID entry. "
+                    + "Regenerate the plist from Firebase and bundle it into the integration test app."
+            );
+        }
+
+        if(!string.Equals(configuredBundleIdentifier, bundleIdentifier, StringComparison.Ordinal)) {
+            throw new InvalidOperationException(
+                $"GoogleService-Info.plist was generated for '{configuredBundleIdentifier}', "
+                    + $"but the integration test app is running as '{bundleIdentifier}'. "
+                    + "Update the app bundle identifier or replace the plist so they match."
+            );
+        }
+    }
+
+    private static NativeFirebaseOptions CreateEmulatorFirebaseOptions()
+    {
+        return new NativeFirebaseOptions(
+            IntegrationTestEnvironment.IosGoogleAppId,
+            IntegrationTestEnvironment.GcmSenderId) {
+            ApiKey = IntegrationTestEnvironment.ApiKey,
+            BundleId = NSBundle.MainBundle.BundleIdentifier,
+            DatabaseUrl = IntegrationTestEnvironment.DatabaseUrl,
+            ProjectId = IntegrationTestEnvironment.ProjectId,
+            StorageBucket = IntegrationTestEnvironment.StorageBucket
+        };
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/Platforms/iOS/Info.plist
+++ b/tests/Plugin.Firebase.IntegrationTests/Platforms/iOS/Info.plist
@@ -29,6 +29,6 @@
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/appicon.appiconset</string>
     <key>MinimumOSVersion</key>
-    <string>14.2</string>
+    <string>15.0</string>
 </dict>
 </plist>

--- a/tests/Plugin.Firebase.IntegrationTests/Platforms/iOS/IntegrationTestEnvironment.ios.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Platforms/iOS/IntegrationTestEnvironment.ios.cs
@@ -1,0 +1,10 @@
+namespace Plugin.Firebase.IntegrationTests;
+
+internal static partial class IntegrationTestEnvironment
+{
+    // ReSharper disable once UnusedParameterInPartialMethod
+    private static partial string? GetPlatformConfigurationValue(string? androidSystemPropertyName)
+    {
+        return null;
+    }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/Platforms/iOS/Program.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Platforms/iOS/Program.cs
@@ -1,7 +1,6 @@
-using ObjCRuntime;
 using UIKit;
 
-namespace Plugin.Firebase.IntegrationTests2;
+namespace Plugin.Firebase.IntegrationTests;
 
 public class Program
 {

--- a/tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj
+++ b/tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj
@@ -24,7 +24,7 @@
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 

--- a/tests/Plugin.Firebase.IntegrationTests/RealFirebaseFactAttribute.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/RealFirebaseFactAttribute.cs
@@ -1,28 +1,239 @@
 namespace Plugin.Firebase.IntegrationTests;
 
 [AttributeUsage(AttributeTargets.Method)]
-internal sealed class RealFirebaseFactAttribute : FactAttribute
+internal sealed class EmulatorBackendFactAttribute : FactAttribute, IIntegrationTestCaseMetadata
 {
-    public RealFirebaseFactAttribute()
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.Emulator;
+
+    public IntegrationTestPlatformRequirement Platform => IntegrationTestPlatformRequirement.Any;
+
+    public string? OptIn => null;
+
+    public EmulatorBackendFactAttribute()
     {
-        if(IntegrationTestEnvironment.UsesEmulatorBackend) {
-            Skip = "This test requires a real Firebase project. Set PLUGIN_FIREBASE_TEST_BACKEND=real to run it.";
-        }
+        Skip = IntegrationTestSkipPolicy.RequireEmulatorBackend();
     }
 }
 
 [AttributeUsage(AttributeTargets.Method)]
-internal sealed class RealFirebaseOptInFactAttribute : FactAttribute
+internal sealed class EmulatorBackendTheoryAttribute : TheoryAttribute, IIntegrationTestCaseMetadata
 {
-    public RealFirebaseOptInFactAttribute(string environmentVariableName)
-    {
-        if(IntegrationTestEnvironment.UsesEmulatorBackend) {
-            Skip = "This test requires a real Firebase project. Set PLUGIN_FIREBASE_TEST_BACKEND=real to run it.";
-            return;
-        }
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.Emulator;
 
-        if(Environment.GetEnvironmentVariable(environmentVariableName) != "1") {
-            Skip = $"Set {environmentVariableName}=1 to run this opt-in real Firebase test.";
-        }
+    public IntegrationTestPlatformRequirement Platform => IntegrationTestPlatformRequirement.Any;
+
+    public string? OptIn => null;
+
+    public EmulatorBackendTheoryAttribute()
+    {
+        Skip = IntegrationTestSkipPolicy.RequireEmulatorBackend();
+    }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class RealFirebaseFactAttribute : FactAttribute, IIntegrationTestCaseMetadata
+{
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.Real;
+
+    public IntegrationTestPlatformRequirement Platform => IntegrationTestPlatformRequirement.Any;
+
+    public string? OptIn => null;
+
+    public RealFirebaseFactAttribute()
+    {
+        Skip = IntegrationTestSkipPolicy.RequireRealBackend();
+    }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class RealFirebaseTheoryAttribute : TheoryAttribute, IIntegrationTestCaseMetadata
+{
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.Real;
+
+    public IntegrationTestPlatformRequirement Platform => IntegrationTestPlatformRequirement.Any;
+
+    public string? OptIn => null;
+
+    public RealFirebaseTheoryAttribute()
+    {
+        Skip = IntegrationTestSkipPolicy.RequireRealBackend();
+    }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class RealFirebaseOptInFactAttribute : FactAttribute, IIntegrationTestCaseMetadata
+{
+    private readonly bool _skipIosSimulator;
+
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.RealOptIn;
+
+    public IntegrationTestPlatformRequirement Platform =>
+        _skipIosSimulator ? IntegrationTestPlatformRequirement.IosDevice : IntegrationTestPlatformRequirement.Any;
+
+    public string? OptIn { get; }
+
+    public RealFirebaseOptInFactAttribute(
+        string environmentVariableName,
+        string? androidSystemPropertyName = null,
+        bool skipIosSimulator = false)
+    {
+        _skipIosSimulator = skipIosSimulator;
+        OptIn = environmentVariableName;
+        Skip = IntegrationTestSkipPolicy.RequireRealBackendOptIn(
+            environmentVariableName,
+            androidSystemPropertyName,
+            skipIosSimulator);
+    }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class RealFirebaseOptInTheoryAttribute : TheoryAttribute, IIntegrationTestCaseMetadata
+{
+    private readonly bool _skipIosSimulator;
+
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.RealOptIn;
+
+    public IntegrationTestPlatformRequirement Platform =>
+        _skipIosSimulator ? IntegrationTestPlatformRequirement.IosDevice : IntegrationTestPlatformRequirement.Any;
+
+    public string? OptIn { get; }
+
+    public RealFirebaseOptInTheoryAttribute(
+        string environmentVariableName,
+        string? androidSystemPropertyName = null,
+        bool skipIosSimulator = false)
+    {
+        _skipIosSimulator = skipIosSimulator;
+        OptIn = environmentVariableName;
+        Skip = IntegrationTestSkipPolicy.RequireRealBackendOptIn(
+            environmentVariableName,
+            androidSystemPropertyName,
+            skipIosSimulator);
+    }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class OptInFactAttribute : FactAttribute, IIntegrationTestCaseMetadata
+{
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.OptIn;
+
+    public IntegrationTestPlatformRequirement Platform => IntegrationTestPlatformRequirement.Any;
+
+    public string? OptIn { get; }
+
+    public OptInFactAttribute(
+        string environmentVariableName,
+        string? androidSystemPropertyName = null)
+    {
+        OptIn = environmentVariableName;
+        Skip = IntegrationTestSkipPolicy.RequireOptIn(environmentVariableName, androidSystemPropertyName);
+    }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class OptInTheoryAttribute : TheoryAttribute, IIntegrationTestCaseMetadata
+{
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.OptIn;
+
+    public IntegrationTestPlatformRequirement Platform => IntegrationTestPlatformRequirement.Any;
+
+    public string? OptIn { get; }
+
+    public OptInTheoryAttribute(
+        string environmentVariableName,
+        string? androidSystemPropertyName = null)
+    {
+        OptIn = environmentVariableName;
+        Skip = IntegrationTestSkipPolicy.RequireOptIn(environmentVariableName, androidSystemPropertyName);
+    }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class AndroidFactAttribute : FactAttribute, IIntegrationTestCaseMetadata
+{
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.Any;
+
+    public IntegrationTestPlatformRequirement Platform => IntegrationTestPlatformRequirement.Android;
+
+    public string? OptIn => null;
+
+    public AndroidFactAttribute()
+    {
+        Skip = IntegrationTestSkipPolicy.RequireAndroid();
+    }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class AndroidTheoryAttribute : TheoryAttribute, IIntegrationTestCaseMetadata
+{
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.Any;
+
+    public IntegrationTestPlatformRequirement Platform => IntegrationTestPlatformRequirement.Android;
+
+    public string? OptIn => null;
+
+    public AndroidTheoryAttribute()
+    {
+        Skip = IntegrationTestSkipPolicy.RequireAndroid();
+    }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class IosFactAttribute : FactAttribute, IIntegrationTestCaseMetadata
+{
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.Any;
+
+    public IntegrationTestPlatformRequirement Platform => IntegrationTestPlatformRequirement.Ios;
+
+    public string? OptIn => null;
+
+    public IosFactAttribute()
+    {
+        Skip = IntegrationTestSkipPolicy.RequireIos();
+    }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class IosTheoryAttribute : TheoryAttribute, IIntegrationTestCaseMetadata
+{
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.Any;
+
+    public IntegrationTestPlatformRequirement Platform => IntegrationTestPlatformRequirement.Ios;
+
+    public string? OptIn => null;
+
+    public IosTheoryAttribute()
+    {
+        Skip = IntegrationTestSkipPolicy.RequireIos();
+    }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class IosDeviceFactAttribute : FactAttribute, IIntegrationTestCaseMetadata
+{
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.Any;
+
+    public IntegrationTestPlatformRequirement Platform => IntegrationTestPlatformRequirement.IosDevice;
+
+    public string? OptIn => null;
+
+    public IosDeviceFactAttribute()
+    {
+        Skip = IntegrationTestSkipPolicy.RequireIosDevice();
+    }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class NonIosSimulatorFactAttribute : FactAttribute, IIntegrationTestCaseMetadata
+{
+    public IntegrationTestBackendRequirement Backend => IntegrationTestBackendRequirement.Any;
+
+    public IntegrationTestPlatformRequirement Platform => IntegrationTestPlatformRequirement.NonIosSimulator;
+
+    public string? OptIn => null;
+
+    public NonIosSimulatorFactAttribute()
+    {
+        Skip = IntegrationTestSkipPolicy.RequireNonIosSimulator();
     }
 }

--- a/tests/Plugin.Firebase.IntegrationTests/SequentialCollectionDefinition.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/SequentialCollectionDefinition.cs
@@ -1,8 +1,4 @@
-using Xunit;
-
 namespace Plugin.Firebase.IntegrationTests;
 
 [CollectionDefinition("Sequential", DisableParallelization = true)]
-public sealed class SequentialCollectionDefinition
-{
-}
+public sealed class SequentialCollectionDefinition;

--- a/tests/Plugin.Firebase.IntegrationTests/TestLoggingAttribute.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/TestLoggingAttribute.cs
@@ -29,7 +29,7 @@ public sealed class TestLoggingAttribute : BeforeAfterTestAttribute
 
 internal static class TestLog
 {
-    private static readonly object Sync = new();
+    private static readonly Lock Sync = new();
 
     public static void Write(string message)
     {


### PR DESCRIPTION
## Summary
- Move MAUI Firebase setup into platform-specific FirebaseTestHost partials.
- Add shared integration-test options, skip policies, diagnostics, timing helpers, and metadata types.
- Add emulator runner/preflight/tool-install scripts and improve xUnit GitHub summaries.
- Update emulator workflow and build docs to use shared scripts.

## Validation
- bash -n scripts/check-integration-environment.sh scripts/install-integration-test-tools.sh scripts/run-integration-emulators.sh
- ruby -c scripts/write-xunit-github-summary.rb
- dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -f net9.0-android -c Debug --no-restore
- dotnet build tests/Plugin.Firebase.IntegrationTests/Plugin.Firebase.IntegrationTests.csproj -f net9.0-ios -c Debug --no-restore