### PR TITLE
Prepare next-release migration and package notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           dotnet build src/Firestore/Firestore.csproj -c Release
           dotnet build src/Functions/Functions.csproj -c Release
           dotnet build src/Installations/Installations.csproj -c Release
+          dotnet build src/PerformanceMonitoring/PerformanceMonitoring.csproj -c Release
           dotnet build src/RemoteConfig/RemoteConfig.csproj -c Release
           dotnet build src/Storage/Storage.csproj -c Release
           dotnet build src/Bundled/Bundled.csproj -c Release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Plugin.Firebase
 
-This is a wrapper library around the native Android and iOS Firebase SDKs which includes cross-platform APIs for most of the Firebase features. Documentation and the included sample app are MAUI-centric, but the plugin should be usable in any cross-platform .NET 10+ project.
+This is a wrapper library around the native Android and iOS Firebase SDKs which includes cross-platform APIs for most of the Firebase features. Documentation and the included sample app are MAUI-centric, but the plugin is also usable in compatible non-MAUI .NET 10 mobile projects.
+
+## Next release upgrade notes
+
+- The next release supports .NET 10 only: `net10.0`, `net10.0-android`, and `net10.0-ios`. .NET 9 is not supported.
+- MAUI apps must use .NET MAUI 10. Compatible non-MAUI .NET 10 Android and iOS apps remain supported.
+- The minimum Firebase iOS binding version increases from 12.5 to 12.7. The minimum operating-system versions remain iOS 15 and Android API level 23.
+- Review the package-specific changes and migration guidance before upgrading: [Auth](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/docs/auth.md), [Cloud Messaging](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/docs/cloud_messaging.md), [Firestore](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/docs/firestore.md), [Functions](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/docs/functions.md), and [Storage](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/docs/storage.md).
 
 ## v4.0 Upgrade Notes
 - The experience of building projects using this plugin has been improved on Windows / Visual Studio. Issues related to hanging builds caused by XamarinBuildDownload and long path issues affecting iOS NuGet packages have been mitigated, if not commpletely resolved.
@@ -185,7 +192,7 @@ In case you would like to run the sample app or the real-Firebase integration ba
 @coop-tim has created a [.NET 8 sample project](https://github.com/coop-tim/maui-sample) with a really good and extensive description. It's targeting iOS and Android with Firebase Cloud Messaging, Analytics and the relevant build pipelines to get them built and pushed into App Center. Definitely worth checking it out!
 
 ## Using Firebase Local Emulator Suite
-If you would like to use the [Firebase Local Emulator Suite](https://firebase.google.com/docs/emulator-suite) for your tests or rapid prototyping you can do so by following the steps of the [Getting started guide](https://firebase.google.com/docs/emulator-suite/connect_and_prototype) and calling the [`UseEmulator(host, port)`](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Shared/Firestore/IFirebaseFirestore.cs#L45) method of the desired firebase service before doing any other operations.
+If you would like to use the [Firebase Local Emulator Suite](https://firebase.google.com/docs/emulator-suite) for your tests or rapid prototyping you can do so by following the steps of the [Getting started guide](https://firebase.google.com/docs/emulator-suite/connect_and_prototype) and calling the [`UseEmulator(host, port)`](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Firestore/Shared/IFirebaseFirestore.cs#L111) method of the desired firebase service before doing any other operations.
 
 For example the [`Plugin.Firebase.IntegrationTests`](https://github.com/TobiasBuchholz/Plugin.Firebase/tree/development/tests/Plugin.Firebase.IntegrationTests) project defaults to emulator-backed Auth, Firestore, Functions, and Storage tests. Its `DeviceRunners.Testing.Targets` reference makes the MAUI device app runnable with standard `dotnet test` commands and TRX output; `scripts/run-integration-emulators.sh` starts the Firebase emulators and seeds Auth around that run. The `integration-emulators-android` and `integration-emulators-ios` GitHub Actions checks run the same suites for pull requests. Use `SIMCTL_CHILD_PLUGIN_FIREBASE_TEST_BACKEND=real` for an iOS simulator or `PLUGIN_FIREBASE_TEST_BACKEND=real` for Android `dotnet test` to opt into a real Firebase project for products without local emulators. Launching the app directly opens the interactive visual runner.
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -7,13 +7,13 @@ Firebase Analytics collects usage and behavior data for your app. The SDK logs t
 
 ## Installation
 ### NuGet
-[![NuGet](https://img.shields.io/nuget/v/plugin.firebase.analytics.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Analytics/)
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.Analytics.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Analytics/)
 
 > Install-Package Plugin.Firebase.Analytics
 
 ## Setup
 
-- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/README.md#basic-setup)
+- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup)
 - When using the standalone `Plugin.Firebase.Analytics` package on Android, initialize Analytics after calling `CrossFirebase.Initialize(...)`:
 
 ```c#
@@ -69,8 +69,8 @@ Omitting a consent type retains its previous status. Obtain and interpret user c
 Take a look at the [documentation](https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/blob/master/docs/Firebase/Analytics/GettingStarted.md) for the AdamE.Firebase.iOS.Analytics packages, because Plugin.Firebase's code is abstracted but still very similar.
 
 Since code should be documenting itself you can also take a look at the following classes:
-- [src/.../IFirebaseAnalytics.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Analytics/Shared/IFirebaseAnalytics.cs)
-- [tests/.../AnalyticsFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/Plugin.Firebase.IntegrationTests/Analytics/AnalyticsFixture.cs)
+- [src/.../IFirebaseAnalytics.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Analytics/Shared/IFirebaseAnalytics.cs)
+- [tests/.../AnalyticsFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/tests/Plugin.Firebase.IntegrationTests/Analytics/AnalyticsFixture.cs)
 
 ### Default event parameters
 
@@ -93,6 +93,13 @@ analytics.SetDefaultEventParameters((IDictionary<string, object>) null);
 Passing a typed null to the dictionary overload clears all default event parameters.
 
 ## Release notes
+
+- Next
+  - Target .NET 10 and raise the minimum Firebase iOS binding version to 12.7; the minimum platform versions remain iOS 15 and Android 23.
+  - Add `SetConsent(...)` with Firebase consent types and statuses.
+  - Add `SetDefaultEventParameters(...)`, including clearing defaults by passing a typed `null`.
+  - Guard standalone Android use before initialization with an actionable `InvalidOperationException`.
+  - Correct nullable contracts for app instance IDs, event parameters, user IDs, and user-property values.
 - Version 3.1.2
   - Add collections support for Analytics (PR #432)
 - Version 3.1.1

--- a/docs/app_check.md
+++ b/docs/app_check.md
@@ -3,12 +3,14 @@
 Firebase App Check helps protect backend resources from abuse by ensuring requests come from your authentic app.
 
 ## Installation
-### Nuget
+### NuGet
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.AppCheck.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.AppCheck/)
+
 > Install-Package Plugin.Firebase.AppCheck
 
 ## Setup
 
-- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/README.md#basic-setup).
+- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup).
 - Configure App Check **before** calling `CrossFirebase.Initialize()`. The plugin uses initialization hooks internally to install the provider factory at the correct moment on each platform (before `Configure()` on iOS, after `InitializeApp()` on Android).
 
 ```c#
@@ -92,3 +94,9 @@ This is the standard .NET Android MSBuild property. It works with both APK and A
 > **Do NOT use** `AndroidPackageFormat=apk` or `EmbedAssembliesIntoApk=true` as a workaround for this issue — those properties serve different purposes (debug speed, distribution format) and are not needed to fix native library compression.
 
 See also the [sample Playground project](../sample/Playground/Playground.csproj) for a working reference.
+
+## Release notes
+
+- Next
+  - Target .NET 10 and raise the minimum Firebase iOS binding version to 12.7; the minimum platform versions remain iOS 15 and Android 23.
+  - Enable nullable reference-type analysis and correct nullable provider-factory, registration, and cross-platform implementation contracts.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -3,14 +3,14 @@
 You can use [Firebase Authentication](https://firebase.google.com/docs/auth) to allow users to sign in to your app using one or more sign-in methods, including email address and password sign-in, and federated identity providers such as Google Sign-in and Facebook Login.
 
 ## Installation
-### Nuget
-[![NuGet](https://img.shields.io/nuget/v/plugin.firebase.auth.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Auth/)
+### NuGet
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.Auth.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Auth/)
 
 > Install-Package Plugin.Firebase.Auth
 
 ## Setup
 
-- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/README.md#basic-setup)
+- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup)
 - Enable Authentication at your project in the [Firebase Console](https://console.firebase.google.com/).
 - When using [Plugin.Firebase.Auth.Google](https://www.nuget.org/packages/Plugin.Firebase.Auth.Google/), add the following lines of code after calling `CrossFirebase.Initialize()`:
 ```c#
@@ -65,10 +65,10 @@ For more specific instructions take a look at the official [Firebase documentati
 Take a look at the [documentation](https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/blob/master/docs/Firebase/Auth/GettingStarted.md) for the AdamE.Firebase.iOS.Auth packages, because Plugin.Firebase's code is abstracted but still very similar.
 
 Since code should be documenting itself you can also take a look at the following classes:
-- [src/.../IFirebaseAuth.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/Auth/IFirebaseAuth.cs)
-- [src/.../IFirebaseUser.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/Auth/IFirebaseUser.cs)
-- [tests/.../AuthFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs)
-- [sample/.../AuthService.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/sample/Playground/Common/Services/Auth/AuthService.cs)
+- [src/.../IFirebaseAuth.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Auth/Shared/IFirebaseAuth.cs)
+- [src/.../IFirebaseUser.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Auth/Shared/IFirebaseUser.cs)
+- [tests/.../AuthFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/tests/Plugin.Firebase.IntegrationTests/Auth/AuthFixture.cs)
+- [sample/.../AuthService.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/sample/Playground/Common/Services/Auth/AuthService.cs)
 
 ### Native provider credentials
 
@@ -159,9 +159,15 @@ In v5:
 - `SignOutAsync()` now follows the same unified exception model when the underlying native Auth SDK reports a failure.
 
 ## Release notes
+
 - Next
+  - Target .NET 10 and raise the minimum Firebase iOS binding version to 12.7; the minimum platform versions remain iOS 15 and Android 23.
+  - Preserve nested token claims as dictionaries and lists instead of platform-native container objects.
+  - Add platform-native credential overloads for signing in and linking users.
   - Add email/password user reauthentication and user-level reload APIs.
   - Mark `ReloadCurrentUserAsync()` obsolete; use `CurrentUser.ReloadAsync()` after checking `CurrentUser` is not `null`.
+  - Add request-based profile updates that distinguish omitted fields, `null`, and empty strings; mark the legacy string overload obsolete.
+  - Correct nullable contracts for the current user and native values returned by Firebase.
 - Version 5.0.1
   - Fix for wrong Core project version dependency at nuget.org
 - Version 5.0.0

--- a/docs/bundled.md
+++ b/docs/bundled.md
@@ -3,7 +3,7 @@ This package bundles all features into a single nuget package for people who wer
 
 ## Installation
 ### NuGet
-[![NuGet](https://img.shields.io/nuget/v/plugin.firebase.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase/)
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase/)
 
 > Install-Package Plugin.Firebase
 
@@ -11,7 +11,7 @@ This package bundles all features into a single nuget package for people who wer
 If you encounter a build error, try to add the package via `dotnet add package Plugin.Firebase`, see [issue #69](https://github.com/TobiasBuchholz/Plugin.Firebase/issues/65) for more information.
 
 ## Setup
-- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/README.md#basic-setup)
+- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup)
 - At `Platforms/Android/Resources/values` add the following line to your `strings.xml`:
 ```
 <resources>
@@ -59,6 +59,13 @@ When `isAnalyticsEnabled` is `true`, the bundled package initializes Firebase An
 The Firebase Performance Monitoring SDK can automatically collect app start, screen rendering, and network data when it is linked into an app. `CrossFirebaseSettings.IsPerformanceMonitoringEnabled` controls runtime collection for the bundled package, but privacy-sensitive apps should also use Firebase's documented Android manifest and iOS plist disable keys before initialization if collection must be disabled before app startup.
 
 ## Release notes
+
+- Next
+  - Support .NET 10 only; MAUI consumers must use .NET MAUI 10.
+  - Raise the minimum Firebase iOS binding version to 12.7 while retaining iOS 15 and Android 23 as the minimum platform versions.
+  - Bundle Plugin.Firebase.Installations and Plugin.Firebase.PerformanceMonitoring.
+  - Add `CrossFirebaseSettings.IsInstallationsEnabled` and `CrossFirebaseSettings.IsPerformanceMonitoringEnabled` to control bundled initialization and Performance Monitoring collection.
+  - Review the next-release migration guidance for [Auth](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/docs/auth.md), [Cloud Messaging](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/docs/cloud_messaging.md), [Firestore](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/docs/firestore.md), [Functions](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/docs/functions.md), and [Storage](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/docs/storage.md).
 - Version 4.2.1
   - Plugin.Firebase.Auth 5.0.1
 - Version 4.2.0

--- a/docs/cloud_messaging.md
+++ b/docs/cloud_messaging.md
@@ -3,14 +3,14 @@
 Firebase Cloud Messaging offers a broad range of messaging options and capabilities. I invite you to read the following [documentation](https://firebase.google.com/docs/cloud-messaging/concept-options) to have a better understanding about notification messages and data messages and what you can do with them using FCM's options.
 
 ## Installation
-### Nuget
-[![NuGet](https://img.shields.io/nuget/v/plugin.firebase.cloud_messaging.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.CloudMessaging/)
+### NuGet
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.CloudMessaging.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.CloudMessaging/)
 
 > Install-Package Plugin.Firebase.CloudMessaging
 
 ## Setup
 
-- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/README.md#basic-setup)
+- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup)
 - Enable Cloud Messaging at your project in the [Firebase Console](https://console.firebase.google.com/)
 - Add the following line of code after calling `CrossFirebase.Initialize()`:
 ```c#
@@ -149,8 +149,8 @@ You can find more specific instructions for android at the official [Firebase do
 Take a look at the [documentation](https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/blob/master/docs/Firebase/CloudMessaging/GettingStarted.md) for the AdamE.Firebase.iOS.CloudMessaging packages, because Plugin.Firebase's code is abstracted but still very similar.
 
 Since code should be documenting itself you can also take a look at the following classes:
-- [src/.../IFirebaseCloudMessaging.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/CloudMessaging/IFirebaseCloudMessaging.cs)
-- [sample/.../PushNotificationService.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/sample/Playground/Common/Services/PushNotification/PushNotificationService.cs)
+- [src/.../IFirebaseCloudMessaging.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/CloudMessaging/Shared/IFirebaseCloudMessaging.cs)
+- [sample/.../PushNotificationService.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/sample/Playground/Common/Services/PushNotification/PushNotificationService.cs)
 
 ## Test with curl
 
@@ -186,6 +186,12 @@ Note: this is a Plugin.Firebase custom field and hence not documented with googl
 If you are having trouble receiving push notifications on your device, take a look at this helpful https://github.com/TobiasBuchholz/Plugin.Firebase/issues/145#issuecomment-1455182588 by @andyzukunft. Additionally he has created a dedicated project to simplify the demonstration on how Firebase Cloud Messaging works: https://github.com/andyzukunft/Plugin.Firebase/tree/fcm-demo/sample/Fcm
 
 ## Release notes
+
+- Next
+  - Target .NET 10 and raise the minimum Firebase iOS binding version to 12.7; the minimum platform versions remain iOS 15 and Android 23.
+  - Register the bundled Android `FirebaseMessagingService` as non-exported and validate it under full Android trimming.
+  - Correct nullable Android notification callbacks.
+  - Expose the sender-specified Android channel as nullable `FCMNotification.ChannelId` for received, foreground, and tapped notifications. The value remains raw and does not change Firebase or app-defined fallback behavior.
 - Version 4.0.1
   - Add iOS action identifier to notification body (PR #547)
 - Version 4.0.0

--- a/docs/core.md
+++ b/docs/core.md
@@ -1,0 +1,24 @@
+# Core
+
+Plugin.Firebase.Core provides the shared Firebase initialization layer used by the feature packages. It is installed transitively with those packages and with the bundled `Plugin.Firebase` package, so most applications do not need to reference it directly.
+
+## Installation
+
+### NuGet
+
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.Core.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Core/)
+
+> Install-Package Plugin.Firebase.Core
+
+## Setup
+
+Follow the repository's [basic setup instructions](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup). Core supplies the platform-specific `CrossFirebase.Initialize(...)` entry points and coordinates initialization hooks used by the feature packages.
+
+The package supports .NET 10 only: `net10.0`, `net10.0-android`, and `net10.0-ios`. MAUI consumers must use .NET MAUI 10; compatible non-MAUI .NET 10 mobile apps can also use the package. The minimum operating-system versions are iOS 15 and Android API level 23.
+
+## Release notes
+
+- Next
+  - Target .NET 10 only and require .NET MAUI 10 for MAUI consumers.
+  - Raise the minimum Firebase iOS binding version to 12.7 while retaining iOS 15 and Android API level 23 as the minimum operating-system versions.
+  - Make the `TryGetDefaultApp` out parameter nullable when no default Android Firebase app exists.

--- a/docs/crashlytics.md
+++ b/docs/crashlytics.md
@@ -3,14 +3,14 @@
 Firebase [Firebase Crashlytics](https://firebase.google.com/docs/crashlytics) is a lightweight, realtime crash reporter that helps you track, prioritize, and fix stability issues that erode your app quality. Crashlytics saves you troubleshooting time by intelligently grouping crashes and highlighting the circumstances that lead up to them.
 
 ## Installation
-### Nuget
-[![NuGet](https://img.shields.io/nuget/v/plugin.firebase.crashlytics.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Crashlytics/)
+### NuGet
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.Crashlytics.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Crashlytics/)
 
 > Install-Package Plugin.Firebase.Crashlytics
 
 ## Setup
 
-- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/README.md#basic-setup)
+- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup)
 - Add the following line of code after calling `CrossFirebase.Initialize()`:
 ```c#
   CrossFirebaseCrashlytics.Current.SetCrashlyticsCollectionEnabled(true);
@@ -51,9 +51,14 @@ To test if everything is setup correctly, restart the app after a forced crash a
 Take a look at the [documentation](https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/blob/master/docs/Firebase/Crashlytics/GettingStarted.md) for the AdamE.Firebase.iOS.Crashlytics packages, because Plugin.Firebase's code is abstracted but still very similar.
 
 Since code should be documenting itself you can also take a look at the following class:
-- [src/.../IFirebaseCrashlytics.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/Crashlytics/IFirebaseCrashlytics.cs)
+- [src/.../IFirebaseCrashlytics.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Crashlytics/Shared/IFirebaseCrashlytics.cs)
 
 ## Release notes
+
+- Next
+  - Target .NET 10 and raise the minimum Firebase iOS binding version to 12.7; the minimum platform versions remain iOS 15 and Android 23.
+  - Document iOS symbol-export diagnostics and Android resource/build-ID troubleshooting.
+  - Support newer Android Crashlytics binding shapes and validate targeted compile compatibility across the tested `Xamarin.Firebase.Crashlytics` 119.x and 120.x packages, up to and including 120.0.5. The package still references 119.0.0 by default; override `XamarinFirebaseCrashlyticsVersion` to use a newer binding.
 - Version 3.1.1
   - Using AdamE.Firebase.iOS.* minimum version 11
 - Version 3.1.0

--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -3,14 +3,14 @@
 Cloud Firestore is a flexible, scalable database for mobile, web, and server development from Firebase and Google Cloud. Like Firebase Realtime Database, it keeps your data in sync across client apps through realtime listeners and offers offline support for mobile and web so you can build responsive apps that work regardless of network latency or Internet connectivity. Cloud Firestore also offers seamless integration with other Firebase and Google Cloud products, including Cloud Functions.
 
 ## Installation
-### Nuget
-[![NuGet](https://img.shields.io/nuget/v/plugin.firebase.firestore.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Firestore/)
+### NuGet
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.Firestore.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Firestore/)
 
 > Install-Package Plugin.Firebase.Firestore
 
 ## Setup
 
-- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/README.md#basic-setup)
+- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup)
 - Enable Cloud Firestore at your project in the [Firebase Console](https://console.firebase.google.com/)
 
 ## Usage
@@ -84,15 +84,21 @@ var name = data["name"] as string;
 Take a look at the [documentation](https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/blob/master/docs/Firebase/CloudFirestore/GettingStarted.md) for the AdamE.Firebase.iOS.CloudFirestore packages, because Plugin.Firebase's code is abstracted but still very similar.
 
 Since code should be documenting itself you can also take a look at the following classes:
-- [src/.../IFirebaseFirestore.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/Firestore/IFirebaseFirestore.cs)
-- [src/.../ICollectionReference.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/Firestore/ICollectionReference.cs)
-- [src/.../IDocumentReference.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/Firestore/IDocumentReference.cs)
-- [src/.../IQuery.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/Firestore/IQuery.cs)
-- [src/.../ITransaction.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/Firestore/ITransaction.cs)
-- [src/.../IWriteBatch.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/Firestore/IWriteBatch.cs)
-- [tests/.../FirestoreFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs)
+- [src/.../IFirebaseFirestore.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Firestore/Shared/IFirebaseFirestore.cs)
+- [src/.../ICollectionReference.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Firestore/Shared/ICollectionReference.cs)
+- [src/.../IDocumentReference.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Firestore/Shared/IDocumentReference.cs)
+- [src/.../IQuery.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Firestore/Shared/IQuery.cs)
+- [src/.../ITransaction.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Firestore/Shared/ITransaction.cs)
+- [src/.../IWriteBatch.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Firestore/Shared/IWriteBatch.cs)
+- [tests/.../FirestoreFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.cs)
 
 ## Release notes
+
+- Next
+  - Target .NET 10 and raise the minimum Firebase iOS binding version to 12.7; the minimum platform versions remain iOS 15 and Android 23.
+  - Correct nullable contracts across snapshots, references, queries, transactions, batches, sentinels, listeners, and data values. `FirestoreSettings` now requires an explicit `host` argument.
+  - Support raw dictionary reads and fix cross-platform conversion of nulls, nested dictionaries, typed collections, enum dictionaries, GeoPoint lists, numeric sentinels, and `SetData` payloads.
+  - Full trimming and Native AOT remain unsupported because POCO mapping relies on reflection; the package is explicitly marked non-trimmable.
 - Version 3.1.3
   - Added the handling of a FieldValue into a Hashmap correctly + Prevent crashing when a list on the server has a null as an entry (PR #437)
 - Version 3.1.2

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -3,33 +3,47 @@
 Cloud Functions for Firebase is a serverless framework that lets you automatically run backend code in response to events triggered by Firebase features and HTTPS requests. Your JavaScript or TypeScript code is stored in Google's cloud and runs in a managed environment. There's no need to manage and scale your own servers.
 
 ## Installation
-### Nuget
-[![NuGet](https://img.shields.io/nuget/v/plugin.firebase.functions.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Functions/)
+
+### NuGet
+
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.Functions.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Functions/)
 
 > Install-Package Plugin.Firebase.Functions
 
 ## Setup
 
-- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/README.md#basic-setup)
+- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup)
 - Enable Cloud Functions at your project in the [Firebase Console](https://console.firebase.google.com/)
 - [Deploy](https://firebase.google.com/docs/functions/get-started?hl=en) your own function
-- Call `CrossFirebaseFunctions.Initialize(string region)` if your functions are deployed outside the default `us-central1` region
+- Call `CrossFirebaseFunctions.Initialize(string? region)` if your functions are deployed outside the default `us-central1` region
 
-Call `CrossFirebaseFunctions.Initialize(string region)` before accessing `CrossFirebaseFunctions.Current` or `CrossFirebaseFunctions.IsSupported`. If you change the region after `Current` has already been created, reacquire `CrossFirebaseFunctions.Current` before creating new callable references. Existing `IFirebaseFunctions` and `IHttpsCallable` references keep using the instance they were created from.
+Call `CrossFirebaseFunctions.Initialize(string? region)` before accessing `CrossFirebaseFunctions.Current` or `CrossFirebaseFunctions.IsSupported`. If you change the region after `Current` has already been created, reacquire `CrossFirebaseFunctions.Current` before creating new callable references. Existing `IFirebaseFunctions` and `IHttpsCallable` references keep using the instance they were created from.
+
+## Next-release migration notes
+
+Typed callable responses now convert the complete native payload instead of deserializing the native object's display string. Object, array, scalar, and null responses can therefore be requested as DTOs or `JsonElement` values. When `TResponse` is `string`, native string payloads remain unquoted strings, while object and array payloads are returned as valid JSON. A native null payload returns `default(TResponse)`.
+
+Regional initialization now recreates an already-created `CrossFirebaseFunctions.Current` instance when the configured region changes and reapplies its emulator host and port. Reacquire `Current` and create new callable references after calling `Initialize`; previously acquired `IFirebaseFunctions` and `IHttpsCallable` references continue to use their original instance.
+
+The region continues to be configured through the global `CrossFirebaseFunctions.Initialize(...)` entry point. The breaking per-region instance redesign proposed in [#661](https://github.com/TobiasBuchholz/Plugin.Firebase/issues/661) is not included in this release.
 
 ## Usage
 
-Take a look at the [documentation](https://firebase.google.com/docs/functions/callable?hl=en#call_the_function) for the official Firebase Cloud Function SKDs, because Plugin.Firebase's code is abstracted but still very similar.
+Take a look at the [documentation](https://firebase.google.com/docs/functions/callable?hl=en#call_the_function) for the official Firebase Cloud Function SDKs, because Plugin.Firebase's code is abstracted but still very similar.
 
 Since code should be documenting itself you can also take a look at the following classes:
-- [src/.../IFirebaseFunctions.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/Functions/IFirebaseFunctions.cs)
-- [src/.../IHttpsCallable.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/Functions/IHttpsCallable.cs)
-- [tests/.../FunctionsFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/Plugin.Firebase.IntegrationTests/Functions/FunctionsFixture.cs)
-- [tests/cloud-functions/.../index.ts](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/cloud-functions/functions/src/index.ts)
+- [IFirebaseFunctions.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Functions/Shared/IFirebaseFunctions.cs)
+- [IHttpsCallable.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/Functions/Shared/IHttpsCallable.cs)
+- [Functions integration tests](https://github.com/TobiasBuchholz/Plugin.Firebase/tree/development/tests/Plugin.Firebase.IntegrationTests/Functions)
+- [Test Cloud Functions](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/tests/cloud-functions/functions/src/index.ts)
 
 ## Release notes
-- Version 4.0.0
-  - Fixed typed callable responses for native object, array, scalar, and null payloads
+
+- Next
+  - Target .NET 10 and raise the minimum Firebase iOS binding version to 12.7; the minimum platform versions remain iOS 15 and Android 23.
+  - Fixed typed callable responses for native object, array, scalar, and null payloads.
+  - Fixed regional initialization after `Current` is created and preserved emulator settings when changing regions.
+  - Kept global region initialization; the breaking redesign in #661 is explicitly excluded.
 - Version 3.1.1
   - Using AdamE.Firebase.iOS.* minimum version 11
 - Version 3.1.0

--- a/docs/installations.md
+++ b/docs/installations.md
@@ -3,13 +3,15 @@
 Firebase Installations provides a stable app installation identifier, auth tokens for the installation, and a client API for deleting the current installation.
 
 ## Installation
-### Nuget
-[![NuGet](https://img.shields.io/nuget/v/plugin.firebase.installations.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Installations/)
+
+### NuGet
+
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.Installations.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Installations/)
 
 > Install-Package Plugin.Firebase.Installations
 
 ## Setup
-- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/README.md#basic-setup).
+- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup).
 - No service-specific initialization is required beyond `CrossFirebase.Initialize(...)`.
 
 ```c#
@@ -31,6 +33,13 @@ await CrossFirebaseInstallations.Current.DeleteAsync();
 Deleting an installation can affect Firebase services that identify app instances by Firebase installation ID, including Cloud Messaging, Remote Config, Analytics, A/B Testing, and In-App Messaging. Use it only for explicit user or test flows where resetting the installation is intended.
 
 ## Further reading
+
 - [Manage Firebase installations](https://firebase.google.com/docs/projects/manage-installations)
 - [Android FirebaseInstallations reference](https://firebase.google.com/docs/reference/android/com/google/firebase/installations/FirebaseInstallations)
 - [Apple Installations reference](https://firebase.google.com/docs/reference/swift/firebaseinstallations/api/reference/Classes/Installations)
+
+## Release notes
+
+- Next
+  - Initial public release targeting .NET 10 with Firebase iOS 12.7, iOS 15, and Android 23 as its initial baselines.
+  - Add installation ID retrieval, auth-token retrieval and forced refresh, and installation deletion.

--- a/docs/performance_monitoring.md
+++ b/docs/performance_monitoring.md
@@ -3,14 +3,16 @@
 Firebase [Performance Monitoring](https://firebase.google.com/docs/perf-mon) helps collect app performance data and supports custom code traces and custom HTTP network request metrics.
 
 ## Installation
-### Nuget
-[![NuGet](https://img.shields.io/nuget/v/plugin.firebase.performancemonitoring.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.PerformanceMonitoring/)
+
+### NuGet
+
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.PerformanceMonitoring.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.PerformanceMonitoring/)
 
 > Install-Package Plugin.Firebase.PerformanceMonitoring
 
 ## Setup
 
-- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/README.md#basic-setup).
+- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup).
 - Use Firebase's official [Performance Monitoring setup docs](https://firebase.google.com/docs/perf-mon/get-started) for Firebase Console and platform configuration.
 - The native Firebase Performance Monitoring SDK can start automatic collection when linked into the app. If collection must be disabled before startup, configure Firebase's documented Android manifest or iOS plist disable keys before initialization.
 - On Android, `Plugin.Firebase.PerformanceMonitoring` uses `Xamarin.Firebase.Perf` v121.0.0, which maps to Firebase Android BoM 33.0.0.
@@ -43,9 +45,12 @@ httpMetric.Stop();
 Take a look at the official Firebase documentation for [custom code traces](https://firebase.google.com/docs/perf-mon/custom-code-traces) and [custom network request metrics](https://firebase.google.com/docs/perf-mon/custom-network-traces), because Plugin.Firebase keeps the API close to the native SDKs.
 
 Since code should be documenting itself you can also take a look at the following classes:
-- [src/.../IFirebasePerformanceMonitoring.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/PerformanceMonitoring/Shared/IFirebasePerformanceMonitoring.cs)
-- [tests/.../PerformanceMonitoringFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/Plugin.Firebase.IntegrationTests/PerformanceMonitoring/PerformanceMonitoringFixture.cs)
+
+- [IFirebasePerformanceMonitoring.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/PerformanceMonitoring/Shared/IFirebasePerformanceMonitoring.cs)
+- [Performance Monitoring integration tests](https://github.com/TobiasBuchholz/Plugin.Firebase/tree/development/tests/Plugin.Firebase.IntegrationTests/PerformanceMonitoring)
 
 ## Release notes
-- Version 4.0.0
-  - Initial Firebase Performance Monitoring support for collection control, custom code traces, and custom HTTP metrics.
+
+- Next
+  - Initial public release targeting .NET 10 with Firebase iOS 12.7, iOS 15, and Android 23 as its initial baselines.
+  - Add collection controls, custom traces, metrics, attributes, and HTTP metrics.

--- a/docs/remote_config.md
+++ b/docs/remote_config.md
@@ -3,14 +3,16 @@
 You can use Firebase Remote Config to define parameters in your app and update their values in the cloud, allowing you to modify the appearance and behavior of your app without distributing an app update.
 
 ## Installation
-### Nuget
-[![NuGet](https://img.shields.io/nuget/v/plugin.firebase.remote_config.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.RemoteConfig/)
+
+### NuGet
+
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.RemoteConfig.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.RemoteConfig/)
 
 > Install-Package Plugin.Firebase.RemoteConfig
 
 ## Setup
 
-- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/README.md#basic-setup)
+- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup)
 - Add a Remote Config key-value pair at your project in the [Firebase Console](https://console.firebase.google.com/)
 
 ## Usage
@@ -32,13 +34,16 @@ registration.Dispose();
 ```
 
 Since code should be documenting itself you can also take a look at the following classes:
-- [src/.../IFirebaseRemoteConfig.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/src/Shared/RemoteConfig/IFirebaseRemoteConfig.cs)
-- [tests/.../RemoteConfigFixture.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/tests/Plugin.Firebase.IntegrationTests/RemoteConfig/RemoteConfigFixture.cs)
+
+- [IFirebaseRemoteConfig.cs](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/src/RemoteConfig/Shared/RemoteConfig/IFirebaseRemoteConfig.cs)
+- [Remote Config integration tests](https://github.com/TobiasBuchholz/Plugin.Firebase/tree/development/tests/Plugin.Firebase.IntegrationTests/RemoteConfig)
 
 ## Release notes
-- Version 4.0.0
-  - Add real-time Remote Config update listener
-  - Using AdamE.Firebase.iOS.* minimum version 12.7.0
+
+- Next
+  - Target .NET 10 and raise the minimum Firebase iOS binding version to 12.7; the minimum platform versions remain iOS 15 and Android 23.
+  - Corrected nullable contracts and native dictionary conversions.
+  - Added real-time Remote Config update listeners; retain and dispose the returned registration to remove a listener.
 - Version 3.1.1
   - Using AdamE.Firebase.iOS.* minimum version 11
 - Version 3.1.0

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -6,13 +6,13 @@ Firebase Storage lets you upload and share user generated content, such as image
 
 ### NuGet
 
-[![NuGet](https://img.shields.io/nuget/v/plugin.firebase.storage.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Storage/)
+[![NuGet](https://img.shields.io/nuget/v/Plugin.Firebase.Storage.svg?maxAge=86400&style=flat)](https://www.nuget.org/packages/Plugin.Firebase.Storage/)
 
 > Install-Package Plugin.Firebase.Storage
 
 ## Setup
 
-- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/master/README.md#basic-setup)
+- Follow the instructions for the [basic setup](https://github.com/TobiasBuchholz/Plugin.Firebase/blob/development/README.md#basic-setup)
 - Enable Storage at your project in the [Firebase Console](https://console.firebase.google.com/)
 
 ## Usage
@@ -30,19 +30,30 @@ Since code should be documenting itself you can also take a look at the followin
 
 ## Next-release migration notes
 
-The .NET 10 release enables nullable-reference analysis for Storage and aligns the shared contracts with values that the native SDKs can omit:
+The .NET 10 release enables nullable-reference analysis for Storage and aligns the shared contracts with values that the native SDKs can omit. These signature changes require callers and custom implementations of the Storage interfaces to account for the following values:
 
-- `IStorageReference.Parent` is null for the root reference.
-- `IStorageListResult.PageToken` is null when there is no next page.
-- `IStorageTaskSnapshot.Metadata` and `Error` are nullable. Successful snapshots have no error; failure snapshots may have no metadata.
-- Optional metadata strings, custom metadata, and `StorageReference` are nullable. The current iOS Firebase SDK no longer exposes a storage reference from metadata, so `StorageReference` is null on iOS.
-- `Generation`, `MetaGeneration`, `CreationTime`, and `UpdatedTime` are nullable value types. Check `HasValue` before using them.
-- Omitted `StorageMetadata` constructor values now remain null instead of becoming `0` or `default(DateTimeOffset)`.
+- `IStorageReference.Parent` is nullable and is `null` for the root reference.
+- `IStorageListResult.PageToken` is nullable and is `null` for the terminal page.
+- `IStorageTaskSnapshot.Metadata` and `Error` are nullable. Successful snapshots have no error, and failure snapshots may have no metadata.
+- `IStorageMetadata.Bucket`, `Name`, `Path`, `CacheControl`, `ContentDisposition`, `ContentEncoding`, `ContentLanguage`, `ContentType`, `CustomMetadata`, `MD5Hash`, and `StorageReference` are nullable.
+- `IStorageMetadata.Generation`, `MetaGeneration`, `CreationTime`, and `UpdatedTime` are nullable value types. Check `HasValue` before using them.
+- Omitted nullable `StorageMetadata` constructor arguments now remain `null` instead of using sentinel `0` or `default(DateTimeOffset)` values. `Size` remains a non-nullable `long` whose default is `0`.
 
-The release also corrects `StorageMetadata` so `creationTime` and `updatedTime` populate their matching properties, and forwards `CacheControl` when metadata is sent to the iOS SDK. These are breaking behavior and signature changes; update callers and any custom implementations of the Storage interfaces before upgrading.
+The current iOS Firebase SDK does not expose an object reference through native metadata, so `IStorageMetadata.StorageReference` is always `null` on iOS. Metadata conversion now maps `creationTime` to `CreationTime` and `updatedTime` to `UpdatedTime`, and sends `CacheControl` to the iOS SDK. Code that compensated for the previously swapped timestamps should remove that workaround.
+
+Additional behavioral changes in this release are:
+
+- `ListAllAsync()` on iOS follows native page tokens until it has buffered every item and prefix; its composed result has a terminal `PageToken` of `null`.
+- `GetBytesAsync(maxDownloadSizeBytes)` and `GetStreamAsync(maxSize)` on iOS enforce the requested maximum even if the native callback returns a larger payload, and fail with a `FirebaseException` instead of returning the oversized data.
+- `IFirebaseStorage.UseEmulator(host, port)` connects the current native Storage instance to the Firebase Storage emulator. Call it before performing any Storage operation.
+- iOS task snapshots propagate native snapshot failures through the nullable `IStorageTaskSnapshot.Error` property as `NSErrorException`; inspect that exception when native error details are needed.
 
 ## Release notes
 
+- Next
+  - Target .NET 10 and raise the minimum Firebase iOS binding version to 12.7; the minimum platform versions remain iOS 15 and Android 23.
+  - Corrected nullable reference and value contracts, constructor defaults, timestamp mapping, iOS metadata forwarding, and native task-snapshot error propagation. See [Next-release migration notes](#next-release-migration-notes).
+  - Added Storage emulator support, fixed iOS `ListAllAsync()` paging, and enforced iOS in-memory download size limits.
 - Version 3.1.1
   - Using AdamE.Firebase.iOS.* minimum version 11
 - Version 3.1.0

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -30,6 +30,7 @@
         <RepositoryUrl>https://github.com/TobiasBuchholz/Plugin.Firebase</RepositoryUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageTags>xamarin, ios, android</PackageTags>
+        <PackageReadmeFile>core.md</PackageReadmeFile>
 
         <Title>Plugin.Firebase</Title>
         <Summary>Xamarin wrapper around the native Android and iOS Firebase SDKs.</Summary>
@@ -61,6 +62,7 @@
         <None Remove=".vs\**" />
         <None Remove=".idea\**" />
         <None Include="..\..\art\icon.png" Pack="true" PackagePath="" />
+        <None Include="..\..\docs\core.md" Pack="true" PackagePath="\"/>
 
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>


### PR DESCRIPTION
## Summary

- document the .NET 10-only and MAUI 10 consumer boundary, with actionable next-release migration guidance
- add one provisional `Next` entry for each of the 13 publishable packages, including new App Check, Core, Installations, and Performance Monitoring coverage
- package a concise Core readme and add Performance Monitoring to the CI package-build list

The publication workflow and publishing guide remain a separate release-preparation gate; this PR does not change package versions or runtime/public APIs.

## Status

This branch has been rebased onto `development` now that #689, #669, and #690 have all merged. It no longer carries their prerequisite commits, and it now contains a single documentation commit targeting `development` directly.

The Storage migration section and the Cloud Messaging `ChannelId` notes were reconciled against the merged implementations rather than the earlier stacked branches.

Two inaccuracies were corrected during that reconciliation:

- the Crashlytics note referred to "19.x and 20.x" packages while naming `Xamarin.Firebase.Crashlytics`, whose tested versions are 119.x and 120.x; it now also records the 119.0.0 default and the `XamarinFirebaseCrashlyticsVersion` override
- the README's Firestore `UseEmulator` link pointed at `src/Shared/Firestore/IFirebaseFirestore.cs`, which no longer exists; this link ships inside the bundled package readme

`Next` headings are still provisional. They are replaced with approved package versions during release prep, once the version matrix in #668 is approved.

## Validation

- `git diff --check`
- verified all 13 package documents have exactly one top-level `Next` entry and use badges matching their `PackageId`
- verified every rewritten in-repo documentation link resolves to a real path
- verified the documented contracts against the merged code: `net10.0;net10.0-android;net10.0-ios` target set, `[12.7.0,)` iOS binding floors, nullable `FCMNotification.ChannelId`, `IsTrimmable=false` for Firestore, required `FirestoreSettings` host, nullable Storage `Parent`/`PageToken`, Storage `UseEmulator` and iOS download-size enforcement, and the bundled Installations/Performance Monitoring settings
- `dotnet build Plugin.Firebase.sln -c Release` (passed with the same 14 pre-existing warnings)
- `dotnet test tests/Plugin.Firebase.UnitTests/Plugin.Firebase.UnitTests.csproj -c Release -f net10.0` (69 passed)
- packed all 13 projects and inspected every nupkg/nuspec: each contains `net10.0`, `net10.0-android36.0`, and `net10.0-ios26.0` assets plus its declared readme; Core's packed `core.md` is byte-identical to `docs/core.md`, and Core shipped without a readme before this change

Tracked by #668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
