### PR TITLE
Preserve Crashlytics' executable header symbol

### DIFF
--- a/docs/crashlytics.md
+++ b/docs/crashlytics.md
@@ -20,26 +20,6 @@ Firebase [Firebase Crashlytics](https://firebase.google.com/docs/crashlytics) is
 - Make sure to start your app without the debugger attached when testing fatal crashes.
 - After forcing a crash, restart the app so Crashlytics can send the report. The crash may take several minutes to appear in the Firebase Console.
 - To enable verbose Firebase logs while diagnosing setup issues, add `-FIRDebugEnabled` to your iOS app launch arguments.
-- If the device log contains `Crashlytics could not find the symbol for the app's main function`, add the following properties to your app project:
-```xml
-<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-    <_ExportSymbolsExplicitly>false</_ExportSymbolsExplicitly>
-    <DebugType>full</DebugType>
-</PropertyGroup>
-```
-- If the symbol error still appears, create `Platforms/iOS/exported_symbols.txt` containing exactly:
-```text
-__mh_execute_header
-```
-Then reference that file from your app project:
-```xml
-<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-    <_ReferencesLinkerFlags Include="-u__mh_execute_header" Visible="false" />
-    <_CustomLinkFlags Include="-exported_symbols_list" Visible="false" />
-    <_CustomLinkFlags Include="$(ProjectDir)Platforms/iOS/exported_symbols.txt" Visible="false" />
-</ItemGroup>
-```
-The exported symbols file must be plain UTF-8 without a byte order mark or other hidden characters. A hidden character before `__mh_execute_header` can cause Release builds to fail during linking.
 - For more specific instructions take a look at the official [Firebase documentation](https://firebase.google.com/docs/crashlytics/get-started?platform=ios)
 
 ### Android specifics

--- a/src/Crashlytics/Crashlytics.csproj
+++ b/src/Crashlytics/Crashlytics.csproj
@@ -68,6 +68,7 @@
         <None Remove=".idea\**" />
         <None Include="..\..\art\icon.png" Pack="true" PackagePath="" />
         <None Include="..\..\docs\crashlytics.md" Pack="true" PackagePath="\"/>
+        <None Include="Plugin.Firebase.Crashlytics.targets" Pack="true" PackagePath="buildTransitive\Plugin.Firebase.Crashlytics.targets" />
 
         <Compile Include="Shared\**\*.cs" />
     </ItemGroup>

--- a/src/Crashlytics/Plugin.Firebase.Crashlytics.targets
+++ b/src/Crashlytics/Plugin.Firebase.Crashlytics.targets
@@ -1,0 +1,7 @@
+<!-- Copyright (c) Microsoft Corporation. -->
+<!-- Licensed under the MIT License. -->
+<Project>
+    <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+        <ReferenceNativeSymbol Include="_mh_execute_header" SymbolType="Function" />
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
The recommendation to use `_ExportSymbolsExplicitly=false` doesn't work anymore, and causes problems.

Examples:

* https://github.com/dotnet/macios/issues/25491
* https://github.com/dotnet/macios/issues/25427
* https://github.com/dotnet/macios/issues/26445

The underlying problem is that the `__mh_execute_header` symbols is required by [Crashlytics](https://github.com/firebase/firebase-ios-sdk/blob/62c9ced7199194a4cc9ce61cf574799dd3e390bd/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m#L474-L478).

So just ensuring `__mh_execute_header` is present in the app is enough to make Crashlytics work (making the `_ExportSymbolsExplicitly=false` sledgehammer solution no longer necessary).

This can be done like this:

```xml
<ItemGroup>
    <ReferenceNativeSymbol Include="_mh_execute_header" SymbolType="Function" />
</ItemGroup>
```

This is implemented using a buildTransitive target inside the iOS NuGet.