### PR TITLE
Fix iOS Firestore numeric reads wrapping out-of-range values

### DIFF
--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -79,6 +79,32 @@ var data = snapshot.Data;
 var name = data["name"] as string;
 ```
 
+Firestore stores whole numbers as 64-bit integers and fractional numbers as doubles. Reading a
+document into a property of a numeric type (`byte`, `sbyte`, `short`, `ushort`, `int`, `uint`,
+`long`, `ulong`, `char`, `float`, `double`, `decimal`, and their nullable forms) converts the
+stored value with `Convert.ChangeType` on both platforms, so:
+
+- A value outside the property's range throws an `OverflowException` rather than silently
+  wrapping to an unrelated number.
+- A fractional value read into an integral property is rounded to even, not truncated, so a
+  stored `13.5` read into a `long` gives `14` and `12.5` gives `12`.
+- `decimal` and `decimal?` properties are supported.
+- A conversion that has no meaning at all throws an `InvalidCastException`, for example a
+  fractional value read into a `char`.
+
+```c#
+// "quantity" holds 300 in Firestore
+[FirestoreProperty("quantity")]
+public byte Quantity { get; private set; } // throws OverflowException on read
+```
+
+Conversion happens when you read `snapshot.Data`, not when the snapshot arrives, so guard that
+access inside snapshot listener callbacks if documents may hold values your model can't
+represent.
+
+Writing a `decimal` property is not supported on either platform and throws an
+`ArgumentException`; store the value as a `double` or `long` instead.
+
 ### Further information
 
 Take a look at the [documentation](https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/blob/master/docs/Firebase/CloudFirestore/GettingStarted.md) for the AdamE.Firebase.iOS.CloudFirestore packages, because Plugin.Firebase's code is abstracted but still very similar.

--- a/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
+++ b/src/Firestore/Platforms/iOS/Extensions/NSObjectExtensions.cs
@@ -130,6 +130,13 @@ public static class NSObjectExtensions
     /// <param name="this">The NSNumber to convert.</param>
     /// <param name="targetType">Optional target type for the conversion.</param>
     /// <returns>The converted numeric value.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the stored value doesn't fit into <paramref name="targetType"/>.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    /// Thrown if the stored value can't be converted to <paramref name="targetType"/> at all,
+    /// for example a fractional value read into a <see cref="char"/>.
+    /// </exception>
     public static object? ToObject(this NSNumber @this, Type? targetType = null)
     {
         if(targetType == null || targetType == typeof(object)) {
@@ -145,29 +152,47 @@ public static class NSObjectExtensions
             case TypeCode.Boolean:
                 return @this.BoolValue;
             case TypeCode.Char:
-                return Convert.ToChar(@this.ByteValue);
             case TypeCode.SByte:
-                return @this.SByteValue;
             case TypeCode.Byte:
-                return @this.ByteValue;
             case TypeCode.Int16:
-                return @this.Int16Value;
             case TypeCode.UInt16:
-                return @this.UInt16Value;
             case TypeCode.Int32:
-                return @this.Int32Value;
             case TypeCode.UInt32:
-                return @this.UInt32Value;
             case TypeCode.Int64:
-                return @this.Int64Value;
             case TypeCode.UInt64:
-                return @this.UInt64Value;
             case TypeCode.Single:
-                return @this.FloatValue;
             case TypeCode.Double:
-                return @this.DoubleValue;
+            case TypeCode.Decimal:
+                return Convert.ChangeType(@this.ToConversionSource(), conversionType);
             default:
                 return null;
+        }
+    }
+
+    /// <summary>
+    /// Gets the stored value in its widest .NET representation, so that
+    /// <see cref="Convert.ChangeType(object, Type)"/> range checks the target conversion
+    /// instead of the NSNumber accessors silently truncating it.
+    /// </summary>
+    /// <remarks>
+    /// This deliberately widens where <see cref="ToUntypedObject"/> preserves the stored width:
+    /// an untyped read hands the caller the value's own type, while a typed read only needs a
+    /// source wide enough for the target's range check. The bool type codes differ for the same
+    /// reason - the typed path resolves <see cref="TypeCode.Boolean"/> before it gets here, so
+    /// "c" is treated as a number rather than guessed to be a bool.
+    /// </remarks>
+    private static object ToConversionSource(this NSNumber @this)
+    {
+        switch(@this.ObjCType) {
+            case "f":
+                return @this.FloatValue;
+            case "d":
+                return @this.DoubleValue;
+            case "Q":
+            case "L":
+                return @this.UInt64Value;
+            default:
+                return @this.Int64Value;
         }
     }
 

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreDictionaryPayloads.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreDictionaryPayloads.cs
@@ -136,3 +136,171 @@ internal sealed class DictionaryContainer : IFirestoreObject
     [FirestoreProperty("nested")]
     public Dictionary<string, Dictionary<string, object?>> Nested { get; private set; } = null!;
 }
+
+[Preserve(AllMembers = true)]
+internal sealed class NumericBoundariesDocument : IFirestoreObject
+{
+    [FirestoreProperty("byte_min")]
+    public byte ByteMin { get; private set; }
+
+    [FirestoreProperty("byte_max")]
+    public byte ByteMax { get; private set; }
+
+    [FirestoreProperty("sbyte_min")]
+    public sbyte SByteMin { get; private set; }
+
+    [FirestoreProperty("sbyte_max")]
+    public sbyte SByteMax { get; private set; }
+
+    [FirestoreProperty("short_min")]
+    public short ShortMin { get; private set; }
+
+    [FirestoreProperty("short_max")]
+    public short ShortMax { get; private set; }
+
+    [FirestoreProperty("ushort_min")]
+    public ushort UShortMin { get; private set; }
+
+    [FirestoreProperty("ushort_max")]
+    public ushort UShortMax { get; private set; }
+
+    [FirestoreProperty("int_min")]
+    public int IntMin { get; private set; }
+
+    [FirestoreProperty("int_max")]
+    public int IntMax { get; private set; }
+
+    [FirestoreProperty("uint_min")]
+    public uint UIntMin { get; private set; }
+
+    [FirestoreProperty("uint_max")]
+    public uint UIntMax { get; private set; }
+
+    [FirestoreProperty("long_min")]
+    public long LongMin { get; private set; }
+
+    [FirestoreProperty("long_max")]
+    public long LongMax { get; private set; }
+
+    [FirestoreProperty("ulong_min")]
+    public ulong ULongMin { get; private set; }
+
+    [FirestoreProperty("ulong_max")]
+    public ulong ULongMax { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class DecimalValuesDocument : IFirestoreObject
+{
+    [FirestoreProperty("integral")]
+    public decimal Integral { get; private set; }
+
+    [FirestoreProperty("fractional")]
+    public decimal Fractional { get; private set; }
+
+    [FirestoreProperty("nullable_present")]
+    public decimal? NullablePresent { get; private set; }
+
+    [FirestoreProperty("nullable_missing")]
+    public decimal? NullableMissing { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class CharValuesDocument : IFirestoreObject
+{
+    [FirestoreProperty("letter")]
+    public char Letter { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class RoundedIntegralsDocument : IFirestoreObject
+{
+    [FirestoreProperty("round_down")]
+    public long RoundDown { get; private set; }
+
+    [FirestoreProperty("round_up")]
+    public long RoundUp { get; private set; }
+
+    [FirestoreProperty("half_to_even_down")]
+    public long HalfToEvenDown { get; private set; }
+
+    [FirestoreProperty("half_to_even_up")]
+    public long HalfToEvenUp { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class ByteWithinRangeDocument : IFirestoreObject
+{
+    [FirestoreProperty("within_byte")]
+    public byte Value { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class ByteRangeDocument : IFirestoreObject
+{
+    [FirestoreProperty("above_byte")]
+    public byte Value { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class SByteRangeDocument : IFirestoreObject
+{
+    [FirestoreProperty("above_sbyte")]
+    public sbyte Value { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class ShortRangeDocument : IFirestoreObject
+{
+    [FirestoreProperty("above_short")]
+    public short Value { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class UShortRangeDocument : IFirestoreObject
+{
+    [FirestoreProperty("above_ushort")]
+    public ushort Value { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class IntRangeDocument : IFirestoreObject
+{
+    [FirestoreProperty("above_int")]
+    public int Value { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class NullableIntRangeDocument : IFirestoreObject
+{
+    [FirestoreProperty("above_int")]
+    public int? Value { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class UIntRangeDocument : IFirestoreObject
+{
+    [FirestoreProperty("below_unsigned")]
+    public uint Value { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class ULongRangeDocument : IFirestoreObject
+{
+    [FirestoreProperty("below_unsigned")]
+    public ulong Value { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class CharRangeDocument : IFirestoreObject
+{
+    [FirestoreProperty("above_char")]
+    public char Value { get; private set; }
+}
+
+[Preserve(AllMembers = true)]
+internal sealed class FractionalCharDocument : IFirestoreObject
+{
+    [FirestoreProperty("fractional")]
+    public char Value { get; private set; }
+}

--- a/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.DictionaryReads.NumericRanges.cs
+++ b/tests/Plugin.Firebase.IntegrationTests/Firestore/FirestoreFixture.DictionaryReads.NumericRanges.cs
@@ -1,0 +1,156 @@
+using Plugin.Firebase.Firestore;
+
+namespace Plugin.Firebase.IntegrationTests.Firestore;
+
+public sealed partial class FirestoreFixture
+{
+    [Fact]
+    public async Task gets_document_data_with_numeric_values_at_type_boundaries()
+    {
+        var sut = CrossFirebaseFirestore.Current;
+        var document = GetTestingDocument(sut, "numeric-boundaries");
+        await document.SetDataAsync(new Dictionary<object, object?> {
+            { "byte_min", 0L },
+            { "byte_max", 255L },
+            { "sbyte_min", -128L },
+            { "sbyte_max", 127L },
+            { "short_min", -32768L },
+            { "short_max", 32767L },
+            { "ushort_min", 0L },
+            { "ushort_max", 65535L },
+            { "int_min", (long) int.MinValue },
+            { "int_max", (long) int.MaxValue },
+            { "uint_min", 0L },
+            { "uint_max", (long) uint.MaxValue },
+            { "long_min", long.MinValue },
+            { "long_max", long.MaxValue },
+            { "ulong_min", 0L },
+            { "ulong_max", long.MaxValue }
+        });
+
+        var data = (await document.GetDocumentSnapshotAsync<NumericBoundariesDocument>()).Data!;
+
+        Assert.Equal(byte.MinValue, data.ByteMin);
+        Assert.Equal(byte.MaxValue, data.ByteMax);
+        Assert.Equal(sbyte.MinValue, data.SByteMin);
+        Assert.Equal(sbyte.MaxValue, data.SByteMax);
+        Assert.Equal(short.MinValue, data.ShortMin);
+        Assert.Equal(short.MaxValue, data.ShortMax);
+        Assert.Equal(ushort.MinValue, data.UShortMin);
+        Assert.Equal(ushort.MaxValue, data.UShortMax);
+        Assert.Equal(int.MinValue, data.IntMin);
+        Assert.Equal(int.MaxValue, data.IntMax);
+        Assert.Equal(uint.MinValue, data.UIntMin);
+        Assert.Equal(uint.MaxValue, data.UIntMax);
+        Assert.Equal(long.MinValue, data.LongMin);
+        Assert.Equal(long.MaxValue, data.LongMax);
+        Assert.Equal(ulong.MinValue, data.ULongMin);
+        Assert.Equal((ulong) long.MaxValue, data.ULongMax);
+    }
+
+    [Fact]
+    public async Task gets_document_data_with_decimal_values()
+    {
+        var sut = CrossFirebaseFirestore.Current;
+        var document = GetTestingDocument(sut, "numeric-decimals");
+        await document.SetDataAsync(new Dictionary<object, object?> {
+            { "integral", 12345L },
+            { "fractional", 12.5 },
+            { "nullable_present", 67890L },
+            { "nullable_missing", null }
+        });
+
+        var data = (await document.GetDocumentSnapshotAsync<DecimalValuesDocument>()).Data!;
+
+        Assert.Equal(12345m, data.Integral);
+        Assert.Equal(12.5m, data.Fractional);
+        Assert.Equal(67890m, data.NullablePresent);
+        Assert.Null(data.NullableMissing);
+
+        var decimals = (await document.GetDocumentSnapshotAsync<Dictionary<string, decimal?>>()).Data!;
+
+        Assert.Equal(12345m, decimals["integral"]);
+        Assert.Equal(12.5m, decimals["fractional"]);
+        Assert.Equal(67890m, decimals["nullable_present"]);
+        Assert.Null(decimals["nullable_missing"]);
+    }
+
+    [Fact]
+    public async Task rounds_fractional_values_read_into_integral_properties()
+    {
+        // Both platforms convert through Convert.ChangeType, which rounds to even instead of
+        // truncating. Firestore only stores fractional numbers as doubles, so this is reachable
+        // whenever a document holds a double for a property declared as an integral type.
+        var sut = CrossFirebaseFirestore.Current;
+        var document = GetTestingDocument(sut, "numeric-rounding");
+        await document.SetDataAsync(new Dictionary<object, object?> {
+            { "round_down", 1.4 },
+            { "round_up", 1.9 },
+            { "half_to_even_down", 12.5 },
+            { "half_to_even_up", 13.5 }
+        });
+
+        var data = (await document.GetDocumentSnapshotAsync<RoundedIntegralsDocument>()).Data!;
+
+        Assert.Equal(1L, data.RoundDown);
+        Assert.Equal(2L, data.RoundUp);
+        Assert.Equal(12L, data.HalfToEvenDown);
+        Assert.Equal(14L, data.HalfToEvenUp);
+    }
+
+    [Fact]
+    public async Task gets_document_data_with_char_values()
+    {
+        var sut = CrossFirebaseFirestore.Current;
+        var document = GetTestingDocument(sut, "numeric-chars");
+        await document.SetDataAsync(new Dictionary<object, object?> {
+            { "letter", 65L },
+            { "above_char", 70000L },
+            { "fractional", 65.5 }
+        });
+
+        var data = (await document.GetDocumentSnapshotAsync<CharValuesDocument>()).Data!;
+        Assert.Equal('A', data.Letter);
+
+        await AssertOutOfRangeAsync<CharRangeDocument>(document);
+
+        // Convert.ChangeType has no double-to-char conversion on either platform.
+        var fractional = await document.GetDocumentSnapshotAsync<FractionalCharDocument>();
+        Assert.Throws<InvalidCastException>(() => _ = fractional.Data);
+    }
+
+    [Fact]
+    public async Task throws_when_document_data_exceeds_the_target_numeric_range()
+    {
+        var sut = CrossFirebaseFirestore.Current;
+        var document = GetTestingDocument(sut, "numeric-out-of-range");
+        await document.SetDataAsync(new Dictionary<object, object?> {
+            { "within_byte", 200L },
+            { "above_byte", 300L },
+            { "above_sbyte", 128L },
+            { "above_short", 40000L },
+            { "above_ushort", 70000L },
+            { "above_int", 5000000000L },
+            { "below_unsigned", -1L }
+        });
+
+        await AssertOutOfRangeAsync<ByteRangeDocument>(document);
+        await AssertOutOfRangeAsync<SByteRangeDocument>(document);
+        await AssertOutOfRangeAsync<ShortRangeDocument>(document);
+        await AssertOutOfRangeAsync<UShortRangeDocument>(document);
+        await AssertOutOfRangeAsync<IntRangeDocument>(document);
+        await AssertOutOfRangeAsync<NullableIntRangeDocument>(document);
+        await AssertOutOfRangeAsync<UIntRangeDocument>(document);
+        await AssertOutOfRangeAsync<ULongRangeDocument>(document);
+
+        // Only properties that map an out-of-range field fail; the rest of the document is fine.
+        var withinRange = (await document.GetDocumentSnapshotAsync<ByteWithinRangeDocument>()).Data!;
+        Assert.Equal((byte) 200, withinRange.Value);
+    }
+
+    private static async Task AssertOutOfRangeAsync<T>(IDocumentReference document)
+    {
+        var snapshot = await document.GetDocumentSnapshotAsync<T>();
+        Assert.Throws<OverflowException>(() => _ = snapshot.Data);
+    }
+}


### PR DESCRIPTION
Fixes #707.

## Problem

`ToObject(NSNumber, Type?)` on iOS read values through accessors such as `ByteValue`, `Int16Value` and `UInt32Value`. Those wrap silently, and the switch had no `TypeCode.Decimal` case, so a `decimal` property was assigned `null` — which reflection turns into `0` for a non-nullable target. Android converts through `Convert.ChangeType`, which range checks and handles `decimal`, so the two platforms disagreed.

Confirmed by running the conversion switch verbatim against Foundation `NSNumber`. Selectors are identical between the iOS and macOS bindings (`ByteValue` → `unsignedCharValue`, and so on), so the harness reproduces iOS semantics:

| stored | target | before | Android |
|---|---|---|---|
| 300 | `byte` | **44** | OverflowException |
| 255 | `byte` | 255 | 255 |
| 40000 | `short` | **-25536** | OverflowException |
| 5000000000 | `int` | **705032704** | OverflowException |
| -1 | `uint` | **4294967295** | OverflowException |
| 12345 | `decimal` | **null → 0** | 12345 |

## Change

`Convert.ChangeType` over the widest lossless representation of the stored value, picked from the `NSNumber`'s `ObjCType`. Out-of-range values throw `OverflowException`; `decimal` and `decimal?` are supported. Re-running the harness against the patched logic gives identical results to Android on every row above.

## Behavior changes

Two conversions change semantics. Both adopt Android's existing behavior rather than introducing a third:

- **Fractional → integral rounds instead of truncating.** `13.5` read into a `long` gives `14`, not `13`. Firestore stores whole numbers as int64, so this is only reachable on a schema mismatch where both answers are lossy. Android has rounded for years with the larger install base, and #707 named `Convert.ChangeType` as the reference.
- **`char` covers the full 0–65535 range** instead of truncating to a byte, and a fractional value read into a `char` throws `InvalidCastException` — a shared `Convert` limitation, now declared on the method and pinned by a test.

Both are documented in `docs/firestore.md` and covered by tests so they can't drift back silently.

## Tests

Three existing behaviors and two new ones in `FirestoreFixture.DictionaryReads.NumericRanges.cs`:

- Min and max boundaries for all eight integral types.
- `decimal`, `decimal?`, present and null, through a typed model and a `Dictionary<string, decimal?>`.
- Out-of-range reads for `byte`, `sbyte`, `short`, `ushort`, `int`, `int?`, `uint`, `ulong`, plus an assertion that only properties mapping an out-of-range field fail while the rest of the document still reads.
- Rounding across `1.4`, `1.9`, `12.5`, `13.5`.
- `char` at `65`, `70000` and `65.5`.

These are plain `[Fact]`s rather than `[IosFact]`s: after the fix this is no longer platform-specific behavior, and running them on both platforms pins the parity.

**Verified:** 73 Firestore tests on an iOS simulator against the Firestore emulator — 71 passed, 2 skipped (Android-only), 0 failed. The two behavior tests fail on the parent commit and pass here; the boundary test passes on both, as a regression guard should. Android target compiles; the Android leg has not been run locally.

## Follow-ups

Adjacent defects found while working on this, filed separately rather than widening the diff:

- #709 — Auth claim reads ignore the requested numeric type (both platforms, different failure modes)
- #710 — enum-typed properties still wrap out-of-range values (both platforms)
- #711 — iOS returns `null` for numeric → `string` reads where Android returns the digits

## Still to land on this branch

The write half: `byte`, `sbyte`, `uint` and `ulong` properties can now be *read* but still throw on write, because `ToNSObject` and Android's `Put` have no case for them. That work is in progress and will be pushed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
